### PR TITLE
Remote-Name header returns capitalized uid instead of LDAP cn — cn attribute never fetched

### DIFF
--- a/internal/controller/user_controller.go
+++ b/internal/controller/user_controller.go
@@ -194,6 +194,9 @@ func (controller *UserController) loginHandler(c *gin.Context) {
 		if search.Email != "" {
 			sessionCookie.Email = search.Email
 		}
+		if search.Name != "" {
+			sessionCookie.Name = search.Name
+		}
 	}
 
 	cookie, err := controller.auth.CreateSession(c, sessionCookie)

--- a/internal/middleware/context_middleware.go
+++ b/internal/middleware/context_middleware.go
@@ -204,7 +204,11 @@ func (m *ContextMiddleware) cookieAuth(ctx context.Context, uuid string, ip stri
 		}
 
 		userContext.LDAP.Groups = user.Groups
-		userContext.LDAP.Name = utils.Capitalize(userContext.LDAP.Username)
+		if search.Name != "" {
+			userContext.LDAP.Name = search.Name
+		} else {
+			userContext.LDAP.Name = utils.Capitalize(userContext.LDAP.Username)
+		}
 
 		userContext.LDAP.Email = utils.CompileUserEmail(userContext.LDAP.Username, m.runtime.CookieDomain)
 		if search.Email != "" {
@@ -291,10 +295,14 @@ func (m *ContextMiddleware) basicAuth(username string, password string) (*model.
 			return nil, nil, fmt.Errorf("error retrieving ldap user details: %w", err)
 		}
 
+		name := search.Name
+		if name == "" {
+			name = utils.Capitalize(username)
+		}
 		userContext.LDAP = &model.LDAPContext{
 			BaseContext: model.BaseContext{
 				Username: username,
-				Name:     utils.Capitalize(username),
+				Name:     name,
 			},
 			Groups: user.Groups,
 		}

--- a/internal/model/users.go
+++ b/internal/model/users.go
@@ -32,5 +32,6 @@ type LocalUser struct {
 type UserSearch struct {
 	Username string
 	Email    string // used for LDAP, we can't throw it to LDAPUser because it would need another cache or an LDAP lookup every time
+	Name     string // used for LDAP cn attribute
 	Type     UserSearchType
 }

--- a/internal/service/auth_service.go
+++ b/internal/service/auth_service.go
@@ -173,7 +173,7 @@ func (auth *AuthService) SearchUser(username string) (*model.UserSearch, error) 
 	}
 
 	if auth.ldap != nil {
-		userDN, email, err := auth.ldap.GetUserInfo(username)
+		userDN, email, cn, err := auth.ldap.GetUserInfo(username)
 
 		if err != nil {
 			return nil, fmt.Errorf("failed to get ldap user: %w", err)
@@ -182,6 +182,7 @@ func (auth *AuthService) SearchUser(username string) (*model.UserSearch, error) 
 		return &model.UserSearch{
 			Username: userDN,
 			Email:    email,
+			Name:     cn,
 			Type:     model.UserLDAP,
 		}, nil
 	}

--- a/internal/service/ldap_service.go
+++ b/internal/service/ldap_service.go
@@ -146,7 +146,7 @@ func (ldap *LdapService) connect() (*ldapgo.Conn, error) {
 	return ldap.conn, nil
 }
 
-func (ldap *LdapService) GetUserInfo(username string) (dn string, email string, err error) {
+func (ldap *LdapService) GetUserInfo(username string) (dn string, email string, cn string, err error) {
 	escapedUsername := ldapgo.EscapeFilter(username)
 	filter := fmt.Sprintf(ldap.config.LDAP.SearchFilter, escapedUsername)
 
@@ -154,7 +154,7 @@ func (ldap *LdapService) GetUserInfo(username string) (dn string, email string, 
 		ldap.config.LDAP.BaseDN,
 		ldapgo.ScopeWholeSubtree, ldapgo.NeverDerefAliases, 0, 0, false,
 		filter,
-		[]string{"dn", "mail"},
+		[]string{"dn", "mail", "cn"},
 		nil,
 	)
 
@@ -163,15 +163,15 @@ func (ldap *LdapService) GetUserInfo(username string) (dn string, email string, 
 
 	searchResult, err := ldap.conn.Search(searchRequest)
 	if err != nil {
-		return "", "", err
+		return "", "", "", err
 	}
 
 	if len(searchResult.Entries) != 1 {
-		return "", "", fmt.Errorf("multiple or no entries found for user %s", username)
+		return "", "", "", fmt.Errorf("multiple or no entries found for user %s", username)
 	}
 
 	entry := searchResult.Entries[0]
-	return entry.DN, entry.GetAttributeValue("mail"), nil
+	return entry.DN, entry.GetAttributeValue("mail"), entry.GetAttributeValue("cn"), nil
 }
 
 func (ldap *LdapService) GetUserCount() (int, error) {


### PR DESCRIPTION
Add "cn" to LDAP GetUserInfo attributes, propagate it through UserSearch.Name, and use it instead of Capitalize(username) when setting the LDAP user's display name in basicAuth, cookieAuth, and session creation

Found via automated repo scanning, fix written and reviewed before opening.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * LDAP-authenticated users now see their directory name when available.
  * Improved name handling across session-cookie and basic authentication.
  * Added a fallback display name when no directory name is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->