### PR TITLE
feat: support OIDC RP-initiated logout

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -167,6 +167,8 @@ TINYAUTH_OAUTH_PROVIDERS_name_AUTHURL=
 TINYAUTH_OAUTH_PROVIDERS_name_TOKENURL=
 # OAuth userinfo URL.
 TINYAUTH_OAUTH_PROVIDERS_name_USERINFOURL=
+# OpenID Connect RP-Initiated Logout end_session_endpoint URL.
+TINYAUTH_OAUTH_PROVIDERS_name_LOGOUTURL=
 # Allow insecure OAuth connections.
 TINYAUTH_OAUTH_PROVIDERS_name_INSECURE=false
 # Provider name in UI.

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -13,6 +13,8 @@ services:
     labels:
       traefik.enable: true
       traefik.http.routers.whoami.rule: Host(`whoami.127.0.0.1.sslip.io`)
+      traefik.http.routers.whoami.entrypoints: websecure
+      traefik.http.routers.whoami.tls: true
       traefik.http.routers.whoami.middlewares: tinyauth
 
   tinyauth-frontend:

--- a/frontend/src/components/quick-actions/quick-actions.tsx
+++ b/frontend/src/components/quick-actions/quick-actions.tsx
@@ -77,6 +77,10 @@ export const QuickActions = () => {
     }
     return "";
   })();
+  const logoutParams =
+    screenParams.redirect_uri && screenParams.login_for !== "oidc"
+      ? { login_for: "app", redirect_uri: screenParams.redirect_uri }
+      : undefined;
 
   const [isOpen, setIsOpen] = useState(false);
 
@@ -126,9 +130,7 @@ export const QuickActions = () => {
     // It is not the OIDC RP-Initiated Logout post_logout_redirect_uri.
     mutationFn: () =>
       axios.post("/api/user/logout", undefined, {
-        params: screenParams.redirect_uri
-          ? { redirect_uri: screenParams.redirect_uri }
-          : undefined,
+        params: logoutParams,
       }),
     mutationKey: ["logout"],
     onSuccess: (response) => {

--- a/frontend/src/components/quick-actions/quick-actions.tsx
+++ b/frontend/src/components/quick-actions/quick-actions.tsx
@@ -122,12 +122,25 @@ export const QuickActions = () => {
   })();
 
   const logoutMutation = useMutation({
-    mutationFn: () => axios.post("/api/user/logout"),
+    // redirect_uri is Tinyauth's existing application-navigation parameter.
+    // It is not the OIDC RP-Initiated Logout post_logout_redirect_uri.
+    mutationFn: () =>
+      axios.post("/api/user/logout", undefined, {
+        params: screenParams.redirect_uri
+          ? { redirect_uri: screenParams.redirect_uri }
+          : undefined,
+      }),
     mutationKey: ["logout"],
-    onSuccess: () => {
+    onSuccess: (response) => {
       toast.success(t("logoutSuccessTitle"), {
         description: t("logoutSuccessSubtitle"),
       });
+
+      const redirectUrl = response.data?.redirectUrl;
+      if (typeof redirectUrl === "string" && redirectUrl.length > 0) {
+        window.location.replace(redirectUrl);
+        return;
+      }
 
       redirectTimer.current = window.setTimeout(() => {
         window.location.replace(`/login${compiledParams}`);

--- a/frontend/src/components/quick-actions/quick-actions.tsx
+++ b/frontend/src/components/quick-actions/quick-actions.tsx
@@ -139,13 +139,12 @@ export const QuickActions = () => {
       });
 
       const redirectUrl = response.data?.redirectUrl;
-      if (typeof redirectUrl === "string" && redirectUrl.length > 0) {
-        window.location.replace(redirectUrl);
-        return;
-      }
-
       redirectTimer.current = window.setTimeout(() => {
-        window.location.replace(`/login${compiledParams}`);
+        if (typeof redirectUrl === "string" && redirectUrl.length > 0) {
+          window.location.replace(redirectUrl);
+        } else {
+          window.location.replace(`/login${compiledParams}`);
+        }
       }, 500);
     },
     onError: () => {

--- a/frontend/src/pages/logout-page.tsx
+++ b/frontend/src/pages/logout-page.tsx
@@ -36,15 +36,17 @@ export const LogoutPage = () => {
     }
     return "";
   })();
+  const logoutParams =
+    screenParams.redirect_uri && screenParams.login_for !== "oidc"
+      ? { login_for: "app", redirect_uri: screenParams.redirect_uri }
+      : undefined;
 
   const logoutMutation = useMutation({
     // redirect_uri is Tinyauth's existing application-navigation parameter.
     // It is not the OIDC RP-Initiated Logout post_logout_redirect_uri.
     mutationFn: () =>
       axios.post("/api/user/logout", undefined, {
-        params: screenParams.redirect_uri
-          ? { redirect_uri: screenParams.redirect_uri }
-          : undefined,
+        params: logoutParams,
       }),
     mutationKey: ["logout"],
     onSuccess: (response) => {

--- a/frontend/src/pages/logout-page.tsx
+++ b/frontend/src/pages/logout-page.tsx
@@ -55,13 +55,12 @@ export const LogoutPage = () => {
       });
 
       const redirectUrl = response.data?.redirectUrl;
-      if (typeof redirectUrl === "string" && redirectUrl.length > 0) {
-        window.location.replace(redirectUrl);
-        return;
-      }
-
       redirectTimer.current = window.setTimeout(() => {
-        window.location.replace(`/login${compiledParams}`);
+        if (typeof redirectUrl === "string" && redirectUrl.length > 0) {
+          window.location.replace(redirectUrl);
+        } else {
+          window.location.replace(`/login${compiledParams}`);
+        }
       }, 500);
     },
     onError: () => {

--- a/frontend/src/pages/logout-page.tsx
+++ b/frontend/src/pages/logout-page.tsx
@@ -38,12 +38,25 @@ export const LogoutPage = () => {
   })();
 
   const logoutMutation = useMutation({
-    mutationFn: () => axios.post("/api/user/logout"),
+    // redirect_uri is Tinyauth's existing application-navigation parameter.
+    // It is not the OIDC RP-Initiated Logout post_logout_redirect_uri.
+    mutationFn: () =>
+      axios.post("/api/user/logout", undefined, {
+        params: screenParams.redirect_uri
+          ? { redirect_uri: screenParams.redirect_uri }
+          : undefined,
+      }),
     mutationKey: ["logout"],
-    onSuccess: () => {
+    onSuccess: (response) => {
       toast.success(t("logoutSuccessTitle"), {
         description: t("logoutSuccessSubtitle"),
       });
+
+      const redirectUrl = response.data?.redirectUrl;
+      if (typeof redirectUrl === "string" && redirectUrl.length > 0) {
+        window.location.replace(redirectUrl);
+        return;
+      }
 
       redirectTimer.current = window.setTimeout(() => {
         window.location.replace(`/login${compiledParams}`);

--- a/internal/assets/migrations/postgres/000004_oauth_id_token.down.sql
+++ b/internal/assets/migrations/postgres/000004_oauth_id_token.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "sessions" DROP COLUMN "oauth_id_token";

--- a/internal/assets/migrations/postgres/000004_oauth_id_token.up.sql
+++ b/internal/assets/migrations/postgres/000004_oauth_id_token.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "sessions" ADD COLUMN "oauth_id_token" TEXT NOT NULL DEFAULT '';

--- a/internal/assets/migrations/sqlite/000012_oauth_id_token.down.sql
+++ b/internal/assets/migrations/sqlite/000012_oauth_id_token.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "sessions" DROP COLUMN "oauth_id_token";

--- a/internal/assets/migrations/sqlite/000012_oauth_id_token.up.sql
+++ b/internal/assets/migrations/sqlite/000012_oauth_id_token.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "sessions" ADD COLUMN "oauth_id_token" TEXT NOT NULL DEFAULT '';

--- a/internal/controller/oauth_controller.go
+++ b/internal/controller/oauth_controller.go
@@ -160,7 +160,7 @@ func (controller *OAuthController) oauthCallbackHandler(c *gin.Context) {
 	}
 
 	code := c.Query("code")
-	_, err = controller.auth.GetOAuthToken(sessionIdCookie, code)
+	token, err := controller.auth.GetOAuthToken(sessionIdCookie, code)
 
 	if err != nil {
 		controller.log.App.Error().Err(err).Msg("Failed to exchange code for token")
@@ -234,6 +234,9 @@ func (controller *OAuthController) oauthCallbackHandler(c *gin.Context) {
 		OAuthGroups: utils.CoalesceToString(user.Groups),
 		OAuthName:   svc.Name(),
 		OAuthSub:    user.Sub,
+	}
+	if idToken, ok := token.Extra("id_token").(string); ok {
+		sessionCookie.OAuthIDToken = idToken
 	}
 
 	controller.log.App.Debug().Msg("Creating session cookie for user")

--- a/internal/controller/user_controller.go
+++ b/internal/controller/user_controller.go
@@ -13,6 +13,7 @@ import (
 	"github.com/tinyauthapp/tinyauth/internal/service"
 	"github.com/tinyauthapp/tinyauth/internal/utils"
 	"github.com/tinyauthapp/tinyauth/internal/utils/logger"
+	"github.com/tinyauthapp/tinyauth/pkg/validators"
 	"go.uber.org/dig"
 
 	"github.com/gin-gonic/gin"
@@ -30,6 +31,7 @@ type TotpRequest struct {
 
 type UserController struct {
 	log     *logger.Logger
+	config  *model.Config
 	runtime *model.RuntimeConfig
 	auth    *service.AuthService
 }
@@ -38,6 +40,7 @@ type UserControllerInput struct {
 	dig.In
 
 	Log           *logger.Logger
+	StaticConfig  *model.Config
 	RuntimeConfig *model.RuntimeConfig
 	RouterGroup   *gin.RouterGroup `name:"apiRouterGroup"`
 	AuthService   *service.AuthService
@@ -46,6 +49,7 @@ type UserControllerInput struct {
 func NewUserController(i UserControllerInput) *UserController {
 	controller := &UserController{
 		log:     i.Log,
+		config:  i.StaticConfig,
 		runtime: i.RuntimeConfig,
 		auth:    i.AuthService,
 	}
@@ -321,31 +325,41 @@ func (controller *UserController) safeLogoutRedirect(raw string) string {
 		return fallback
 	}
 
-	target, err := url.Parse(raw)
-	if err != nil || target.Host == "" || target.User != nil {
-		return fallback
-	}
-	if target.Scheme != "http" && target.Scheme != "https" {
-		return fallback
-	}
-
 	appURL, err := url.Parse(controller.runtime.AppURL)
 	if err != nil {
 		return fallback
 	}
-	if appURL.Scheme == "https" && target.Scheme != "https" {
+
+	allowedSchemes := []string{"http", "https"}
+	if appURL.Scheme == "https" {
+		allowedSchemes = []string{"https"}
+	}
+
+	schemeValidator := validators.NewDomainValidator(validators.DomainValidatorOptions{
+		WithScheme:     true,
+		AllowedSchemes: allowedSchemes,
+	})
+	hostname, err := schemeValidator.SafeHostname(raw)
+	if err != nil {
 		return fallback
 	}
 
-	targetHost := strings.ToLower(target.Hostname())
-	appHost := strings.ToLower(appURL.Hostname())
-	if targetHost == appHost {
+	domainValidator := validators.NewDomainValidator(validators.DomainValidatorOptions{
+		WithPort: true,
+	})
+	err = domainValidator.Validate(raw, controller.runtime.AppURL)
+	if err == nil {
 		return raw
 	}
 
-	cookieDomain := strings.TrimPrefix(strings.ToLower(controller.runtime.CookieDomain), ".")
-	if cookieDomain != "" &&
-		(targetHost == cookieDomain || strings.HasSuffix(targetHost, "."+cookieDomain)) {
+	if !errors.Is(err, validators.ErrHostnameMismatch) ||
+		controller.config == nil ||
+		!controller.config.Auth.SubdomainsEnabled {
+		return fallback
+	}
+
+	cookieDomain := strings.ToLower(controller.runtime.CookieDomain)
+	if hostname == cookieDomain || strings.HasSuffix(hostname, "."+cookieDomain) {
 		return raw
 	}
 

--- a/internal/controller/user_controller.go
+++ b/internal/controller/user_controller.go
@@ -240,7 +240,11 @@ func (controller *UserController) logoutHandler(c *gin.Context) {
 	requestedRedirectURI := c.Query("redirect_uri")
 	redirectURI := controller.safeLogoutRedirect(requestedRedirectURI)
 
-	userContext, contextErr := new(model.UserContext).NewFromGin(c)
+	userContext, err := new(model.UserContext).NewFromGin(c)
+	if err != nil {
+		userContext = nil
+	}
+
 	providerID := ""
 	idToken := ""
 	if userContext != nil && userContext.IsOAuth() {
@@ -262,10 +266,10 @@ func (controller *UserController) logoutHandler(c *gin.Context) {
 
 		http.SetCookie(c.Writer, cookie)
 
-		if contextErr == nil {
+		if userContext != nil {
 			controller.log.AuditLogout(userContext.GetUsername(), userContext.GetProviderID(), c.ClientIP())
 		} else {
-			controller.log.App.Warn().Err(contextErr).Msg("Failed to get user context during logout, logging audit with unknown user")
+			controller.log.App.Warn().Msg("Failed to get user context during logout, logging audit with unknown user")
 			controller.log.AuditLogout("unknown", "unknown", c.ClientIP())
 		}
 	} else if errors.Is(err, http.ErrNoCookie) {

--- a/internal/controller/user_controller.go
+++ b/internal/controller/user_controller.go
@@ -238,25 +238,17 @@ func (controller *UserController) logoutHandler(c *gin.Context) {
 
 	userContext, contextErr := new(model.UserContext).NewFromGin(c)
 	providerID := ""
-	if contextErr == nil && userContext.IsOAuth() {
-		providerID = userContext.GetProviderID()
+	idToken := ""
+	if userContext != nil && userContext.IsOAuth() {
+		providerID = userContext.OAuth.ID
+		idToken = userContext.OAuth.IDToken
 	}
 
-	idToken := ""
-	sessionProviderID := ""
 	uuid, err := c.Cookie(controller.runtime.SessionCookieName)
 	if err == nil {
-		session, sessionErr := controller.auth.GetSession(c, uuid)
-		if sessionErr != nil {
-			controller.log.App.Warn().Err(sessionErr).Msg("Failed to get session during logout, continuing without session-backed logout metadata")
-		} else {
-			idToken = session.OAuthIDToken
-			sessionProviderID = session.Provider
-		}
-
-		cookie, deleteErr := controller.auth.DeleteSession(c, uuid)
-		if deleteErr != nil {
-			controller.log.App.Error().Err(deleteErr).Msg("Error deleting session on logout")
+		cookie, err := controller.auth.DeleteSession(c, uuid)
+		if err != nil {
+			controller.log.App.Error().Err(err).Msg("Error deleting session on logout")
 			c.JSON(http.StatusInternalServerError, gin.H{
 				"status":  http.StatusInternalServerError,
 				"message": "Internal Server Error",
@@ -281,18 +273,6 @@ func (controller *UserController) logoutHandler(c *gin.Context) {
 			"message": "Internal Server Error",
 		})
 		return
-	}
-
-	// If middleware context is missing, fall back to the just-loaded session
-	// provider. If there is no session metadata either, a deployment with exactly
-	// one OAuth provider can still terminate that provider's SSO session.
-	if providerID == "" && contextErr != nil && isSessionOAuthProvider(sessionProviderID) {
-		providerID = sessionProviderID
-	}
-	if providerID == "" && contextErr != nil && sessionProviderID == "" && len(controller.runtime.OAuthProviders) == 1 {
-		for id := range controller.runtime.OAuthProviders {
-			providerID = id
-		}
 	}
 
 	response := gin.H{
@@ -333,15 +313,6 @@ func (controller *UserController) ssoLogoutCallbackHandler(c *gin.Context) {
 	// the already-validated Tinyauth application return URI across the OP hop.
 	redirectURI := controller.safeLogoutRedirect(c.Query("state"))
 	c.Redirect(http.StatusFound, redirectURI)
-}
-
-func isSessionOAuthProvider(providerID string) bool {
-	switch providerID {
-	case "", "local", "ldap", "tailscale":
-		return false
-	default:
-		return true
-	}
 }
 
 func (controller *UserController) safeLogoutRedirect(raw string) string {

--- a/internal/controller/user_controller.go
+++ b/internal/controller/user_controller.go
@@ -371,11 +371,8 @@ func buildOAuthLogoutURL(provider model.OAuthServiceConfig, callbackURL, idToken
 	if err != nil || logoutURL.Host == "" {
 		return "", fmt.Errorf("invalid logout URL")
 	}
-	if logoutURL.Scheme != "http" && logoutURL.Scheme != "https" {
+	if logoutURL.Scheme != "https" {
 		return "", fmt.Errorf("unsupported logout URL scheme")
-	}
-	if logoutURL.Scheme == "http" && !provider.Insecure {
-		return "", fmt.Errorf("insecure logout URL requires insecure OAuth provider")
 	}
 
 	query := logoutURL.Query()

--- a/internal/controller/user_controller.go
+++ b/internal/controller/user_controller.go
@@ -237,7 +237,10 @@ func (controller *UserController) logoutHandler(c *gin.Context) {
 	// redirect_uri is a Tinyauth UI/navigation parameter. It is not an
 	// OpenID Connect RP-Initiated Logout parameter. The standardized OP-facing
 	// parameters are added later by buildOAuthLogoutURL.
-	requestedRedirectURI := c.Query("redirect_uri")
+	requestedRedirectURI := ""
+	if c.Query("login_for") == "app" {
+		requestedRedirectURI = c.Query("redirect_uri")
+	}
 	redirectURI := controller.safeLogoutRedirect(requestedRedirectURI)
 
 	userContext, err := new(model.UserContext).NewFromGin(c)

--- a/internal/controller/user_controller.go
+++ b/internal/controller/user_controller.go
@@ -313,6 +313,9 @@ func (controller *UserController) logoutHandler(c *gin.Context) {
 		logoutURL, buildErr := buildOAuthLogoutURL(provider, callbackURL, idToken, redirectURI)
 		if buildErr != nil {
 			controller.log.App.Warn().Err(buildErr).Str("provider", providerID).Msg("Invalid OAuth logout URL, skipping provider logout")
+			if requestedRedirectURI != "" {
+				response["redirectUrl"] = redirectURI
+			}
 		} else {
 			response["redirectUrl"] = logoutURL
 		}

--- a/internal/controller/user_controller.go
+++ b/internal/controller/user_controller.go
@@ -301,9 +301,9 @@ func (controller *UserController) logoutHandler(c *gin.Context) {
 		//   post_logout_redirect_uri
 		//   state
 		callbackURL := controller.runtime.AppURL + "/api/user/logout/callback"
-		logoutURL, buildErr := buildOAuthLogoutURL(provider, callbackURL, idToken, redirectURI)
-		if buildErr != nil {
-			controller.log.App.Warn().Err(buildErr).Str("provider", providerID).Msg("Invalid OAuth logout URL, skipping provider logout")
+		logoutURL, err := buildOAuthLogoutURL(provider, callbackURL, idToken, redirectURI)
+		if err != nil {
+			controller.log.App.Warn().Err(err).Str("provider", providerID).Msg("Invalid OAuth logout URL, skipping provider logout")
 			if requestedRedirectURI != "" {
 				response["redirectUrl"] = redirectURI
 			}

--- a/internal/controller/user_controller.go
+++ b/internal/controller/user_controller.go
@@ -293,7 +293,7 @@ func (controller *UserController) logoutHandler(c *gin.Context) {
 		//   id_token_hint
 		//   post_logout_redirect_uri
 		//   state
-		callbackURL := strings.TrimRight(controller.runtime.AppURL, "/") + "/api/user/logout/callback"
+		callbackURL := controller.runtime.AppURL + "/api/user/logout/callback"
 		logoutURL, buildErr := buildOAuthLogoutURL(provider, callbackURL, idToken, redirectURI)
 		if buildErr != nil {
 			controller.log.App.Warn().Err(buildErr).Str("provider", providerID).Msg("Invalid OAuth logout URL, skipping provider logout")

--- a/internal/controller/user_controller.go
+++ b/internal/controller/user_controller.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
+	"strings"
 	"time"
 
 	"github.com/tinyauthapp/tinyauth/internal/model"
@@ -51,6 +53,7 @@ func NewUserController(i UserControllerInput) *UserController {
 	userGroup := i.RouterGroup.Group("/user")
 	userGroup.POST("/login", controller.loginHandler)
 	userGroup.POST("/logout", controller.logoutHandler)
+	userGroup.GET("/logout/callback", controller.ssoLogoutCallbackHandler)
 	userGroup.POST("/totp", controller.totpHandler)
 	userGroup.POST("/tailscale", controller.tailscaleHandler)
 
@@ -227,51 +230,180 @@ func (controller *UserController) loginHandler(c *gin.Context) {
 func (controller *UserController) logoutHandler(c *gin.Context) {
 	controller.log.App.Debug().Msg("Logout attempt")
 
-	uuid, err := c.Cookie(controller.runtime.SessionCookieName)
+	// redirect_uri is a Tinyauth UI/navigation parameter. It is not an
+	// OpenID Connect RP-Initiated Logout parameter. The standardized OP-facing
+	// parameters are added later by buildOAuthLogoutURL.
+	requestedRedirectURI := c.Query("redirect_uri")
+	redirectURI := controller.safeLogoutRedirect(requestedRedirectURI)
 
-	if err != nil {
-		if errors.Is(err, http.ErrNoCookie) {
-			controller.log.App.Warn().Msg("Logout attempt without session cookie, treating as successful logout")
-			c.JSON(200, gin.H{
-				"status":  200,
-				"message": "Logout successful",
+	userContext, contextErr := new(model.UserContext).NewFromGin(c)
+	providerID := ""
+	if contextErr == nil && userContext.IsOAuth() {
+		providerID = userContext.GetProviderID()
+	}
+
+	idToken := ""
+	sessionProviderID := ""
+	uuid, err := c.Cookie(controller.runtime.SessionCookieName)
+	if err == nil {
+		session, sessionErr := controller.auth.GetSession(c, uuid)
+		if sessionErr != nil {
+			controller.log.App.Warn().Err(sessionErr).Msg("Failed to get session during logout, continuing without session-backed logout metadata")
+		} else {
+			idToken = session.OAuthIDToken
+			sessionProviderID = session.Provider
+		}
+
+		cookie, deleteErr := controller.auth.DeleteSession(c, uuid)
+		if deleteErr != nil {
+			controller.log.App.Error().Err(deleteErr).Msg("Error deleting session on logout")
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"status":  http.StatusInternalServerError,
+				"message": "Internal Server Error",
 			})
 			return
 		}
-		controller.log.App.Error().Err(err).Msg("Error retrieving session cookie on logout")
-		c.JSON(500, gin.H{
-			"status":  500,
-			"message": "Internal Server Error",
-		})
-		return
-	}
 
-	cookie, err := controller.auth.DeleteSession(c, uuid)
+		http.SetCookie(c.Writer, cookie)
 
-	if err != nil {
-		controller.log.App.Error().Err(err).Msg("Error deleting session on logout")
-		c.JSON(500, gin.H{
-			"status":  500,
-			"message": "Internal Server Error",
-		})
-		return
-	}
-
-	context, err := new(model.UserContext).NewFromGin(c)
-
-	if err == nil {
-		controller.log.AuditLogout(context.GetUsername(), context.GetProviderID(), c.ClientIP())
+		if contextErr == nil {
+			controller.log.AuditLogout(userContext.GetUsername(), userContext.GetProviderID(), c.ClientIP())
+		} else {
+			controller.log.App.Warn().Err(contextErr).Msg("Failed to get user context during logout, logging audit with unknown user")
+			controller.log.AuditLogout("unknown", "unknown", c.ClientIP())
+		}
+	} else if errors.Is(err, http.ErrNoCookie) {
+		controller.log.App.Warn().Msg("Logout attempt without session cookie, treating as successful logout")
 	} else {
-		controller.log.App.Warn().Err(err).Msg("Failed to get user context during logout, logging audit with unknown user")
-		controller.log.AuditLogout("unknown", "unknown", c.ClientIP())
+		controller.log.App.Error().Err(err).Msg("Error retrieving session cookie on logout")
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"status":  http.StatusInternalServerError,
+			"message": "Internal Server Error",
+		})
+		return
 	}
 
-	http.SetCookie(c.Writer, cookie)
+	// If middleware context is missing, fall back to the just-loaded session
+	// provider. If there is no session metadata either, a deployment with exactly
+	// one OAuth provider can still terminate that provider's SSO session.
+	if providerID == "" && contextErr != nil && isSessionOAuthProvider(sessionProviderID) {
+		providerID = sessionProviderID
+	}
+	if providerID == "" && contextErr != nil && sessionProviderID == "" && len(controller.runtime.OAuthProviders) == 1 {
+		for id := range controller.runtime.OAuthProviders {
+			providerID = id
+		}
+	}
 
-	c.JSON(200, gin.H{
-		"status":  200,
+	response := gin.H{
+		"status":  http.StatusOK,
 		"message": "Logout successful",
-	})
+	}
+
+	provider, ok := controller.runtime.OAuthProviders[providerID]
+	if ok && provider.LogoutURL != "" {
+		// OpenID Connect RP-Initiated Logout 1.0:
+		// https://openid.net/specs/openid-connect-rpinitiated-1_0-final.html#RPLogout
+		//
+		// OP-facing standardized parameters:
+		//   id_token_hint
+		//   post_logout_redirect_uri
+		//   state
+		callbackURL := strings.TrimRight(controller.runtime.AppURL, "/") + "/api/user/logout/callback"
+		logoutURL, buildErr := buildOAuthLogoutURL(provider, callbackURL, idToken, redirectURI)
+		if buildErr != nil {
+			controller.log.App.Warn().Err(buildErr).Str("provider", providerID).Msg("Invalid OAuth logout URL, skipping provider logout")
+		} else {
+			response["redirectUrl"] = logoutURL
+		}
+	} else if requestedRedirectURI != "" {
+		// Non-OIDC/local logout can still return to the validated application.
+		response["redirectUrl"] = redirectURI
+	}
+
+	c.JSON(http.StatusOK, response)
+}
+
+func (controller *UserController) ssoLogoutCallbackHandler(c *gin.Context) {
+	// state is defined by OpenID Connect RP-Initiated Logout 1.0 as an opaque
+	// RP value that the OP returns unchanged after logout. We use it to carry
+	// the already-validated Tinyauth application return URI across the OP hop.
+	redirectURI := controller.safeLogoutRedirect(c.Query("state"))
+	c.Redirect(http.StatusFound, redirectURI)
+}
+
+func isSessionOAuthProvider(providerID string) bool {
+	switch providerID {
+	case "", "local", "ldap", "tailscale":
+		return false
+	default:
+		return true
+	}
+}
+
+func (controller *UserController) safeLogoutRedirect(raw string) string {
+	fallback := controller.runtime.AppURL
+	if raw == "" {
+		return fallback
+	}
+
+	target, err := url.Parse(raw)
+	if err != nil || target.Host == "" || target.User != nil {
+		return fallback
+	}
+	if target.Scheme != "http" && target.Scheme != "https" {
+		return fallback
+	}
+
+	appURL, err := url.Parse(controller.runtime.AppURL)
+	if err != nil {
+		return fallback
+	}
+	if appURL.Scheme == "https" && target.Scheme != "https" {
+		return fallback
+	}
+
+	targetHost := strings.ToLower(target.Hostname())
+	appHost := strings.ToLower(appURL.Hostname())
+	if targetHost == appHost {
+		return raw
+	}
+
+	cookieDomain := strings.TrimPrefix(strings.ToLower(controller.runtime.CookieDomain), ".")
+	if cookieDomain != "" &&
+		(targetHost == cookieDomain || strings.HasSuffix(targetHost, "."+cookieDomain)) {
+		return raw
+	}
+
+	return fallback
+}
+
+func buildOAuthLogoutURL(provider model.OAuthServiceConfig, callbackURL, idToken, state string) (string, error) {
+	logoutURL, err := url.Parse(provider.LogoutURL)
+	if err != nil || logoutURL.Host == "" {
+		return "", fmt.Errorf("invalid logout URL")
+	}
+	if logoutURL.Scheme != "http" && logoutURL.Scheme != "https" {
+		return "", fmt.Errorf("unsupported logout URL scheme")
+	}
+	if logoutURL.Scheme == "http" && !provider.Insecure {
+		return "", fmt.Errorf("insecure logout URL requires insecure OAuth provider")
+	}
+
+	query := logoutURL.Query()
+	if provider.ClientID != "" {
+		query.Set("client_id", provider.ClientID)
+	}
+	if idToken != "" {
+		query.Set("id_token_hint", idToken)
+	}
+	query.Set("post_logout_redirect_uri", callbackURL)
+	if state != "" {
+		query.Set("state", state)
+	}
+	logoutURL.RawQuery = query.Encode()
+
+	return logoutURL.String(), nil
 }
 
 func (controller *UserController) totpHandler(c *gin.Context) {

--- a/internal/controller/user_controller_sso_logout_test.go
+++ b/internal/controller/user_controller_sso_logout_test.go
@@ -1,0 +1,217 @@
+package controller
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/steveiliop56/ding"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tinyauthapp/tinyauth/internal/model"
+	"github.com/tinyauthapp/tinyauth/internal/repository"
+	"github.com/tinyauthapp/tinyauth/internal/repository/memory"
+	"github.com/tinyauthapp/tinyauth/internal/service"
+	"github.com/tinyauthapp/tinyauth/internal/test"
+	"github.com/tinyauthapp/tinyauth/internal/utils/logger"
+)
+
+func TestSafeLogoutRedirect(t *testing.T) {
+	controller := &UserController{
+		runtime: &model.RuntimeConfig{
+			AppURL:       "https://auth.example.com",
+			CookieDomain: "example.com",
+		},
+	}
+
+	assert.Equal(
+		t,
+		"https://app.example.com/",
+		controller.safeLogoutRedirect("https://app.example.com/"),
+	)
+	assert.Equal(
+		t,
+		"https://auth.example.com",
+		controller.safeLogoutRedirect("https://evil.example.net/"),
+	)
+	assert.Equal(
+		t,
+		"https://auth.example.com",
+		controller.safeLogoutRedirect("javascript:alert(1)"),
+	)
+	assert.Equal(
+		t,
+		"https://auth.example.com",
+		controller.safeLogoutRedirect("http://app.example.com/"),
+	)
+}
+
+func TestSSOLogoutUsesServerSideIDToken(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	log := logger.NewLogger().WithTestConfig()
+	log.Init()
+
+	cfg, runtime := test.CreateTestConfigs(t)
+	runtime.OAuthProviders = map[string]model.OAuthServiceConfig{
+		"pocketid": {
+			ClientID:  "client-id",
+			LogoutURL: "https://id.example.com/api/oidc/end-session",
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	store := memory.New()
+	_, err := store.CreateSession(ctx, repository.CreateSessionParams{
+		UUID:         "oauth-session",
+		Username:     "user@example.com",
+		Email:        "user@example.com",
+		Name:         "Test User",
+		Provider:     "pocketid",
+		OAuthGroups:  "admins",
+		Expiry:       time.Now().Add(time.Hour).Unix(),
+		CreatedAt:    time.Now().Unix(),
+		OAuthName:    "Pocket ID",
+		OAuthSub:     "sub-123",
+		OAuthIDToken: "id-token",
+	})
+	require.NoError(t, err)
+
+	dg := ding.New(ctx)
+	authService, err := service.NewAuthService(service.AuthServiceInput{
+		Log:     log,
+		Config:  &cfg,
+		Runtime: &runtime,
+		Ctx:     ctx,
+		Ding:    dg,
+		Queries: store,
+	})
+	require.NoError(t, err)
+
+	router := gin.New()
+	router.Use(func(c *gin.Context) {
+		c.Set("context", &model.UserContext{
+			Authenticated: true,
+			Provider:      model.ProviderOAuth,
+			OAuth: &model.OAuthContext{
+				BaseContext: model.BaseContext{
+					Username: "user@example.com",
+					Name:     "Test User",
+					Email:    "user@example.com",
+				},
+				DisplayName: "Pocket ID",
+				ID:          "pocketid",
+			},
+		})
+		c.Next()
+	})
+
+	NewUserController(UserControllerInput{
+		Log:           log,
+		RuntimeConfig: &runtime,
+		RouterGroup:   router.Group("/api"),
+		AuthService:   authService,
+	})
+
+	recorder := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/user/logout?redirect_uri=https://app.example.com/", nil)
+	req.AddCookie(&http.Cookie{
+		Name:  runtime.SessionCookieName,
+		Value: "oauth-session",
+	})
+
+	router.ServeHTTP(recorder, req)
+
+	require.Equal(t, http.StatusOK, recorder.Code)
+	require.Len(t, recorder.Result().Cookies(), 1)
+	assert.Equal(t, runtime.SessionCookieName, recorder.Result().Cookies()[0].Name)
+
+	var response struct {
+		RedirectURL string `json:"redirectUrl"`
+	}
+	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
+	require.NotEmpty(t, response.RedirectURL)
+
+	parsed, err := url.Parse(response.RedirectURL)
+	require.NoError(t, err)
+	assert.Equal(t, "https", parsed.Scheme)
+	assert.Equal(t, "id.example.com", parsed.Host)
+	assert.Equal(t, "id-token", parsed.Query().Get("id_token_hint"))
+	assert.Equal(t, "client-id", parsed.Query().Get("client_id"))
+	assert.Equal(t, "https://app.example.com/", parsed.Query().Get("state"))
+	assert.Equal(
+		t,
+		"https://tinyauth.example.com/api/user/logout/callback",
+		parsed.Query().Get("post_logout_redirect_uri"),
+	)
+}
+
+func TestBuildOAuthLogoutURL(t *testing.T) {
+	got, err := buildOAuthLogoutURL(
+		model.OAuthServiceConfig{
+			ClientID:  "client-id",
+			LogoutURL: "https://id.example.com/api/oidc/end-session",
+		},
+		"https://auth.example.com/api/user/logout/callback",
+		"id-token",
+		"https://app.example.com/",
+	)
+	require.NoError(t, err)
+
+	parsed, err := url.Parse(got)
+	require.NoError(t, err)
+	assert.Equal(t, "https", parsed.Scheme)
+	assert.Equal(t, "id.example.com", parsed.Host)
+	assert.Equal(t, "/api/oidc/end-session", parsed.Path)
+	assert.Equal(t, "client-id", parsed.Query().Get("client_id"))
+	assert.Equal(t, "id-token", parsed.Query().Get("id_token_hint"))
+	assert.Equal(t, "https://app.example.com/", parsed.Query().Get("state"))
+	assert.Equal(
+		t,
+		"https://auth.example.com/api/user/logout/callback",
+		parsed.Query().Get("post_logout_redirect_uri"),
+	)
+}
+
+func TestBuildOAuthLogoutURLRejectsHTTPUnlessProviderIsInsecure(t *testing.T) {
+	_, err := buildOAuthLogoutURL(
+		model.OAuthServiceConfig{
+			LogoutURL: "http://id.example.com/api/oidc/end-session",
+		},
+		"https://auth.example.com/api/user/logout/callback",
+		"id-token",
+		"https://app.example.com/",
+	)
+	require.Error(t, err)
+
+	got, err := buildOAuthLogoutURL(
+		model.OAuthServiceConfig{
+			ClientID:  "client-id",
+			LogoutURL: "http://id.example.com/api/oidc/end-session",
+			Insecure:  true,
+		},
+		"https://auth.example.com/api/user/logout/callback",
+		"id-token",
+		"https://app.example.com/",
+	)
+	require.NoError(t, err)
+
+	parsed, err := url.Parse(got)
+	require.NoError(t, err)
+	assert.Equal(t, "http", parsed.Scheme)
+	assert.Equal(t, "id.example.com", parsed.Host)
+	assert.Equal(t, "id-token", parsed.Query().Get("id_token_hint"))
+	assert.Equal(t, "client-id", parsed.Query().Get("client_id"))
+	assert.Equal(
+		t,
+		"https://auth.example.com/api/user/logout/callback",
+		parsed.Query().Get("post_logout_redirect_uri"),
+	)
+}

--- a/internal/controller/user_controller_sso_logout_test.go
+++ b/internal/controller/user_controller_sso_logout_test.go
@@ -21,46 +21,6 @@ import (
 	"github.com/tinyauthapp/tinyauth/internal/utils/logger"
 )
 
-func TestSafeLogoutRedirect(t *testing.T) {
-	controller := &UserController{
-		runtime: &model.RuntimeConfig{
-			AppURL:       "https://auth.example.com",
-			CookieDomain: "example.com",
-		},
-	}
-
-	assert.Equal(
-		t,
-		"https://app.example.com/",
-		controller.safeLogoutRedirect("https://app.example.com/"),
-	)
-	assert.Equal(
-		t,
-		"https://auth.example.com",
-		controller.safeLogoutRedirect("https://evil.example.net/"),
-	)
-	assert.Equal(
-		t,
-		"https://auth.example.com",
-		controller.safeLogoutRedirect("https://badexample.com/"),
-	)
-	assert.Equal(
-		t,
-		"https://auth.example.com",
-		controller.safeLogoutRedirect("https://evil.example.net@app.example.com/"),
-	)
-	assert.Equal(
-		t,
-		"https://auth.example.com",
-		controller.safeLogoutRedirect("javascript:alert(1)"),
-	)
-	assert.Equal(
-		t,
-		"https://auth.example.com",
-		controller.safeLogoutRedirect("http://app.example.com/"),
-	)
-}
-
 func TestSSOLogoutUsesServerSideIDToken(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
@@ -126,6 +86,7 @@ func TestSSOLogoutUsesServerSideIDToken(t *testing.T) {
 
 	NewUserController(UserControllerInput{
 		Log:           log,
+		StaticConfig:  &cfg,
 		RuntimeConfig: &runtime,
 		RouterGroup:   router.Group("/api"),
 		AuthService:   authService,
@@ -170,7 +131,7 @@ func TestSSOLogoutFallsBackToRedirectURIWhenProviderLogoutURLIsInvalid(t *testin
 	log := logger.NewLogger().WithTestConfig()
 	log.Init()
 
-	_, runtime := test.CreateTestConfigs(t)
+	cfg, runtime := test.CreateTestConfigs(t)
 	runtime.OAuthProviders = map[string]model.OAuthServiceConfig{
 		"pocketid": {
 			LogoutURL: "http://id.example.com/api/oidc/end-session",
@@ -197,6 +158,7 @@ func TestSSOLogoutFallsBackToRedirectURIWhenProviderLogoutURLIsInvalid(t *testin
 
 	NewUserController(UserControllerInput{
 		Log:           log,
+		StaticConfig:  &cfg,
 		RuntimeConfig: &runtime,
 		RouterGroup:   router.Group("/api"),
 	})

--- a/internal/controller/user_controller_sso_logout_test.go
+++ b/internal/controller/user_controller_sso_logout_test.go
@@ -118,6 +118,7 @@ func TestSSOLogoutUsesServerSideIDToken(t *testing.T) {
 				},
 				DisplayName: "Pocket ID",
 				ID:          "pocketid",
+				IDToken:     "id-token",
 			},
 		})
 		c.Next()

--- a/internal/controller/user_controller_sso_logout_test.go
+++ b/internal/controller/user_controller_sso_logout_test.go
@@ -42,6 +42,16 @@ func TestSafeLogoutRedirect(t *testing.T) {
 	assert.Equal(
 		t,
 		"https://auth.example.com",
+		controller.safeLogoutRedirect("https://badexample.com/"),
+	)
+	assert.Equal(
+		t,
+		"https://auth.example.com",
+		controller.safeLogoutRedirect("https://evil.example.net@app.example.com/"),
+	)
+	assert.Equal(
+		t,
+		"https://auth.example.com",
 		controller.safeLogoutRedirect("javascript:alert(1)"),
 	)
 	assert.Equal(

--- a/internal/controller/user_controller_sso_logout_test.go
+++ b/internal/controller/user_controller_sso_logout_test.go
@@ -21,197 +21,221 @@ import (
 	"github.com/tinyauthapp/tinyauth/internal/utils/logger"
 )
 
-func TestSSOLogoutUsesServerSideIDToken(t *testing.T) {
-	gin.SetMode(gin.TestMode)
-
-	log := logger.NewLogger().WithTestConfig()
-	log.Init()
-
-	cfg, runtime := test.CreateTestConfigs(t)
-	runtime.OAuthProviders = map[string]model.OAuthServiceConfig{
-		"pocketid": {
-			ClientID:  "client-id",
-			LogoutURL: "https://id.example.com/api/oidc/end-session",
-		},
-	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
-
-	store := memory.New()
-	_, err := store.CreateSession(ctx, repository.CreateSessionParams{
-		UUID:         "oauth-session",
-		Username:     "user@example.com",
-		Email:        "user@example.com",
-		Name:         "Test User",
-		Provider:     "pocketid",
-		OAuthGroups:  "admins",
-		Expiry:       time.Now().Add(time.Hour).Unix(),
-		CreatedAt:    time.Now().Unix(),
-		OAuthName:    "Pocket ID",
-		OAuthSub:     "sub-123",
-		OAuthIDToken: "id-token",
-	})
-	require.NoError(t, err)
-
-	dg := ding.New(ctx)
-	authService, err := service.NewAuthService(service.AuthServiceInput{
-		Log:     log,
-		Config:  &cfg,
-		Runtime: &runtime,
-		Ctx:     ctx,
-		Ding:    dg,
-		Queries: store,
-	})
-	require.NoError(t, err)
-
-	router := gin.New()
-	router.Use(func(c *gin.Context) {
-		c.Set("context", &model.UserContext{
-			Authenticated: true,
-			Provider:      model.ProviderOAuth,
-			OAuth: &model.OAuthContext{
-				BaseContext: model.BaseContext{
-					Username: "user@example.com",
-					Name:     "Test User",
-					Email:    "user@example.com",
-				},
-				DisplayName: "Pocket ID",
-				ID:          "pocketid",
-				IDToken:     "id-token",
-			},
-		})
-		c.Next()
-	})
-
-	NewUserController(UserControllerInput{
-		Log:           log,
-		StaticConfig:  &cfg,
-		RuntimeConfig: &runtime,
-		RouterGroup:   router.Group("/api"),
-		AuthService:   authService,
-	})
-
-	recorder := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, "/api/user/logout?login_for=app&redirect_uri=https://app.example.com/", nil)
-	req.AddCookie(&http.Cookie{
-		Name:  runtime.SessionCookieName,
-		Value: "oauth-session",
-	})
-
-	router.ServeHTTP(recorder, req)
-
-	require.Equal(t, http.StatusOK, recorder.Code)
-	require.Len(t, recorder.Result().Cookies(), 1)
-	assert.Equal(t, runtime.SessionCookieName, recorder.Result().Cookies()[0].Name)
-
-	var response struct {
-		RedirectURL string `json:"redirectUrl"`
-	}
-	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
-	require.NotEmpty(t, response.RedirectURL)
-
-	parsed, err := url.Parse(response.RedirectURL)
-	require.NoError(t, err)
-	assert.Equal(t, "https", parsed.Scheme)
-	assert.Equal(t, "id.example.com", parsed.Host)
-	assert.Equal(t, "id-token", parsed.Query().Get("id_token_hint"))
-	assert.Equal(t, "client-id", parsed.Query().Get("client_id"))
-	assert.Equal(t, "https://app.example.com/", parsed.Query().Get("state"))
-	assert.Equal(
-		t,
-		"https://tinyauth.example.com/api/user/logout/callback",
-		parsed.Query().Get("post_logout_redirect_uri"),
-	)
+type logoutResponse struct {
+	RedirectURL string `json:"redirectUrl"`
 }
 
-func TestSSOLogoutFallsBackToRedirectURIWhenProviderLogoutURLIsInvalid(t *testing.T) {
+func TestSSOLogout(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
-	log := logger.NewLogger().WithTestConfig()
-	log.Init()
+	tests := []struct {
+		description string
+		provider    model.OAuthServiceConfig
+		session     *repository.CreateSessionParams
+		userContext *model.UserContext
+		requestPath string
+		validate    func(t *testing.T, recorder *httptest.ResponseRecorder)
+	}{
+		{
+			description: "Uses context ID token for provider logout",
+			provider: model.OAuthServiceConfig{
+				ClientID:  "client-id",
+				LogoutURL: "https://id.example.com/api/oidc/end-session",
+			},
+			session: &repository.CreateSessionParams{
+				UUID:         "oauth-session",
+				Username:     "user@example.com",
+				Email:        "user@example.com",
+				Name:         "Test User",
+				Provider:     "pocketid",
+				OAuthGroups:  "admins",
+				Expiry:       time.Now().Add(time.Hour).Unix(),
+				CreatedAt:    time.Now().Unix(),
+				OAuthName:    "Pocket ID",
+				OAuthSub:     "sub-123",
+				OAuthIDToken: "id-token",
+			},
+			userContext: newOAuthUserContext("pocketid", "id-token"),
+			requestPath: "/api/user/logout?login_for=app&redirect_uri=https://app.example.com/",
+			validate: func(t *testing.T, recorder *httptest.ResponseRecorder) {
+				require.Equal(t, http.StatusOK, recorder.Code)
+				require.Len(t, recorder.Result().Cookies(), 1)
+				assert.Equal(t, "tinyauth-session", recorder.Result().Cookies()[0].Name)
 
-	cfg, runtime := test.CreateTestConfigs(t)
-	runtime.OAuthProviders = map[string]model.OAuthServiceConfig{
-		"pocketid": {
-			LogoutURL: "http://id.example.com/api/oidc/end-session",
+				response := parseLogoutResponse(t, recorder)
+				require.NotEmpty(t, response.RedirectURL)
+
+				parsed, err := url.Parse(response.RedirectURL)
+				require.NoError(t, err)
+				assert.Equal(t, "https", parsed.Scheme)
+				assert.Equal(t, "id.example.com", parsed.Host)
+				assert.Equal(t, "id-token", parsed.Query().Get("id_token_hint"))
+				assert.Equal(t, "client-id", parsed.Query().Get("client_id"))
+				assert.Equal(t, "https://app.example.com/", parsed.Query().Get("state"))
+				assert.Equal(
+					t,
+					"https://tinyauth.example.com/api/user/logout/callback",
+					parsed.Query().Get("post_logout_redirect_uri"),
+				)
+			},
+		},
+		{
+			description: "Falls back to app redirect when provider logout URL is invalid",
+			provider: model.OAuthServiceConfig{
+				LogoutURL: "http://id.example.com/api/oidc/end-session",
+			},
+			userContext: newOAuthUserContext("pocketid", ""),
+			requestPath: "/api/user/logout?login_for=app&redirect_uri=https://app.example.com/",
+			validate: func(t *testing.T, recorder *httptest.ResponseRecorder) {
+				require.Equal(t, http.StatusOK, recorder.Code)
+
+				response := parseLogoutResponse(t, recorder)
+				assert.Equal(t, "https://app.example.com/", response.RedirectURL)
+			},
 		},
 	}
 
-	router := gin.New()
-	router.Use(func(c *gin.Context) {
-		c.Set("context", &model.UserContext{
-			Authenticated: true,
-			Provider:      model.ProviderOAuth,
-			OAuth: &model.OAuthContext{
-				BaseContext: model.BaseContext{
-					Username: "user@example.com",
-					Name:     "Test User",
-					Email:    "user@example.com",
-				},
-				DisplayName: "Pocket ID",
-				ID:          "pocketid",
-			},
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			log := logger.NewLogger().WithTestConfig()
+			log.Init()
+
+			cfg, runtime := test.CreateTestConfigs(t)
+			runtime.OAuthProviders = map[string]model.OAuthServiceConfig{
+				"pocketid": tc.provider,
+			}
+
+			ctx, cancel := context.WithCancel(context.Background())
+			t.Cleanup(cancel)
+
+			store := memory.New()
+			var authService *service.AuthService
+			if tc.session != nil {
+				_, err := store.CreateSession(ctx, *tc.session)
+				require.NoError(t, err)
+
+				dg := ding.New(ctx)
+				authService, err = service.NewAuthService(service.AuthServiceInput{
+					Log:     log,
+					Config:  &cfg,
+					Runtime: &runtime,
+					Ctx:     ctx,
+					Ding:    dg,
+					Queries: store,
+				})
+				require.NoError(t, err)
+			}
+
+			router := gin.New()
+			if tc.userContext != nil {
+				router.Use(func(c *gin.Context) {
+					c.Set("context", tc.userContext)
+					c.Next()
+				})
+			}
+
+			NewUserController(UserControllerInput{
+				Log:           log,
+				StaticConfig:  &cfg,
+				RuntimeConfig: &runtime,
+				RouterGroup:   router.Group("/api"),
+				AuthService:   authService,
+			})
+
+			recorder := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodPost, tc.requestPath, nil)
+			if tc.session != nil {
+				req.AddCookie(&http.Cookie{
+					Name:  runtime.SessionCookieName,
+					Value: tc.session.UUID,
+				})
+			}
+
+			router.ServeHTTP(recorder, req)
+
+			tc.validate(t, recorder)
 		})
-		c.Next()
-	})
-
-	NewUserController(UserControllerInput{
-		Log:           log,
-		StaticConfig:  &cfg,
-		RuntimeConfig: &runtime,
-		RouterGroup:   router.Group("/api"),
-	})
-
-	recorder := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, "/api/user/logout?login_for=app&redirect_uri=https://app.example.com/", nil)
-
-	router.ServeHTTP(recorder, req)
-
-	require.Equal(t, http.StatusOK, recorder.Code)
-
-	var response struct {
-		RedirectURL string `json:"redirectUrl"`
 	}
-	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
-	assert.Equal(t, "https://app.example.com/", response.RedirectURL)
 }
 
 func TestBuildOAuthLogoutURL(t *testing.T) {
-	got, err := buildOAuthLogoutURL(
-		model.OAuthServiceConfig{
-			ClientID:  "client-id",
-			LogoutURL: "https://id.example.com/api/oidc/end-session",
+	tests := []struct {
+		description string
+		provider    model.OAuthServiceConfig
+		expectError bool
+		validate    func(t *testing.T, parsed *url.URL)
+	}{
+		{
+			description: "Builds provider logout URL with OIDC logout parameters",
+			provider: model.OAuthServiceConfig{
+				ClientID:  "client-id",
+				LogoutURL: "https://id.example.com/api/oidc/end-session",
+			},
+			validate: func(t *testing.T, parsed *url.URL) {
+				assert.Equal(t, "https", parsed.Scheme)
+				assert.Equal(t, "id.example.com", parsed.Host)
+				assert.Equal(t, "/api/oidc/end-session", parsed.Path)
+				assert.Equal(t, "client-id", parsed.Query().Get("client_id"))
+				assert.Equal(t, "id-token", parsed.Query().Get("id_token_hint"))
+				assert.Equal(t, "https://app.example.com/", parsed.Query().Get("state"))
+				assert.Equal(
+					t,
+					"https://auth.example.com/api/user/logout/callback",
+					parsed.Query().Get("post_logout_redirect_uri"),
+				)
+			},
 		},
-		"https://auth.example.com/api/user/logout/callback",
-		"id-token",
-		"https://app.example.com/",
-	)
-	require.NoError(t, err)
+		{
+			description: "Rejects HTTP provider logout URL",
+			provider: model.OAuthServiceConfig{
+				LogoutURL: "http://id.example.com/api/oidc/end-session",
+			},
+			expectError: true,
+		},
+	}
 
-	parsed, err := url.Parse(got)
-	require.NoError(t, err)
-	assert.Equal(t, "https", parsed.Scheme)
-	assert.Equal(t, "id.example.com", parsed.Host)
-	assert.Equal(t, "/api/oidc/end-session", parsed.Path)
-	assert.Equal(t, "client-id", parsed.Query().Get("client_id"))
-	assert.Equal(t, "id-token", parsed.Query().Get("id_token_hint"))
-	assert.Equal(t, "https://app.example.com/", parsed.Query().Get("state"))
-	assert.Equal(
-		t,
-		"https://auth.example.com/api/user/logout/callback",
-		parsed.Query().Get("post_logout_redirect_uri"),
-	)
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			got, err := buildOAuthLogoutURL(
+				tc.provider,
+				"https://auth.example.com/api/user/logout/callback",
+				"id-token",
+				"https://app.example.com/",
+			)
+			if tc.expectError {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			parsed, err := url.Parse(got)
+			require.NoError(t, err)
+			tc.validate(t, parsed)
+		})
+	}
 }
 
-func TestBuildOAuthLogoutURLRejectsHTTP(t *testing.T) {
-	_, err := buildOAuthLogoutURL(
-		model.OAuthServiceConfig{
-			LogoutURL: "http://id.example.com/api/oidc/end-session",
+func newOAuthUserContext(providerID, idToken string) *model.UserContext {
+	return &model.UserContext{
+		Authenticated: true,
+		Provider:      model.ProviderOAuth,
+		OAuth: &model.OAuthContext{
+			BaseContext: model.BaseContext{
+				Username: "user@example.com",
+				Name:     "Test User",
+				Email:    "user@example.com",
+			},
+			DisplayName: "Pocket ID",
+			ID:          providerID,
+			IDToken:     idToken,
 		},
-		"https://auth.example.com/api/user/logout/callback",
-		"id-token",
-		"https://app.example.com/",
-	)
-	require.Error(t, err)
+	}
+}
+
+func parseLogoutResponse(t *testing.T, recorder *httptest.ResponseRecorder) logoutResponse {
+	t.Helper()
+
+	var response logoutResponse
+	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
+	return response
 }

--- a/internal/controller/user_controller_sso_logout_test.go
+++ b/internal/controller/user_controller_sso_logout_test.go
@@ -93,7 +93,7 @@ func TestSSOLogoutUsesServerSideIDToken(t *testing.T) {
 	})
 
 	recorder := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, "/api/user/logout?redirect_uri=https://app.example.com/", nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/user/logout?login_for=app&redirect_uri=https://app.example.com/", nil)
 	req.AddCookie(&http.Cookie{
 		Name:  runtime.SessionCookieName,
 		Value: "oauth-session",
@@ -164,7 +164,7 @@ func TestSSOLogoutFallsBackToRedirectURIWhenProviderLogoutURLIsInvalid(t *testin
 	})
 
 	recorder := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, "/api/user/logout?redirect_uri=https://app.example.com/", nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/user/logout?login_for=app&redirect_uri=https://app.example.com/", nil)
 
 	router.ServeHTTP(recorder, req)
 

--- a/internal/controller/user_controller_sso_logout_test.go
+++ b/internal/controller/user_controller_sso_logout_test.go
@@ -204,7 +204,7 @@ func TestBuildOAuthLogoutURL(t *testing.T) {
 	)
 }
 
-func TestBuildOAuthLogoutURLRejectsHTTPUnlessProviderIsInsecure(t *testing.T) {
+func TestBuildOAuthLogoutURLRejectsHTTP(t *testing.T) {
 	_, err := buildOAuthLogoutURL(
 		model.OAuthServiceConfig{
 			LogoutURL: "http://id.example.com/api/oidc/end-session",
@@ -214,28 +214,4 @@ func TestBuildOAuthLogoutURLRejectsHTTPUnlessProviderIsInsecure(t *testing.T) {
 		"https://app.example.com/",
 	)
 	require.Error(t, err)
-
-	got, err := buildOAuthLogoutURL(
-		model.OAuthServiceConfig{
-			ClientID:  "client-id",
-			LogoutURL: "http://id.example.com/api/oidc/end-session",
-			Insecure:  true,
-		},
-		"https://auth.example.com/api/user/logout/callback",
-		"id-token",
-		"https://app.example.com/",
-	)
-	require.NoError(t, err)
-
-	parsed, err := url.Parse(got)
-	require.NoError(t, err)
-	assert.Equal(t, "http", parsed.Scheme)
-	assert.Equal(t, "id.example.com", parsed.Host)
-	assert.Equal(t, "id-token", parsed.Query().Get("id_token_hint"))
-	assert.Equal(t, "client-id", parsed.Query().Get("client_id"))
-	assert.Equal(
-		t,
-		"https://auth.example.com/api/user/logout/callback",
-		parsed.Query().Get("post_logout_redirect_uri"),
-	)
 }

--- a/internal/controller/user_controller_sso_logout_test.go
+++ b/internal/controller/user_controller_sso_logout_test.go
@@ -163,6 +163,57 @@ func TestSSOLogoutUsesServerSideIDToken(t *testing.T) {
 	)
 }
 
+func TestSSOLogoutFallsBackToRedirectURIWhenProviderLogoutURLIsInvalid(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	log := logger.NewLogger().WithTestConfig()
+	log.Init()
+
+	_, runtime := test.CreateTestConfigs(t)
+	runtime.OAuthProviders = map[string]model.OAuthServiceConfig{
+		"pocketid": {
+			LogoutURL: "http://id.example.com/api/oidc/end-session",
+		},
+	}
+
+	router := gin.New()
+	router.Use(func(c *gin.Context) {
+		c.Set("context", &model.UserContext{
+			Authenticated: true,
+			Provider:      model.ProviderOAuth,
+			OAuth: &model.OAuthContext{
+				BaseContext: model.BaseContext{
+					Username: "user@example.com",
+					Name:     "Test User",
+					Email:    "user@example.com",
+				},
+				DisplayName: "Pocket ID",
+				ID:          "pocketid",
+			},
+		})
+		c.Next()
+	})
+
+	NewUserController(UserControllerInput{
+		Log:           log,
+		RuntimeConfig: &runtime,
+		RouterGroup:   router.Group("/api"),
+	})
+
+	recorder := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/user/logout?redirect_uri=https://app.example.com/", nil)
+
+	router.ServeHTTP(recorder, req)
+
+	require.Equal(t, http.StatusOK, recorder.Code)
+
+	var response struct {
+		RedirectURL string `json:"redirectUrl"`
+	}
+	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
+	assert.Equal(t, "https://app.example.com/", response.RedirectURL)
+}
+
 func TestBuildOAuthLogoutURL(t *testing.T) {
 	got, err := buildOAuthLogoutURL(
 		model.OAuthServiceConfig{

--- a/internal/controller/user_controller_sso_logout_test.go
+++ b/internal/controller/user_controller_sso_logout_test.go
@@ -27,6 +27,7 @@ type logoutResponse struct {
 
 func TestSSOLogout(t *testing.T) {
 	gin.SetMode(gin.TestMode)
+	cfg, runtime := test.CreateTestConfigs(t)
 
 	tests := []struct {
 		description string
@@ -95,14 +96,13 @@ func TestSSOLogout(t *testing.T) {
 		},
 	}
 
-	for _, tc := range tests {
-		t.Run(tc.description, func(t *testing.T) {
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
 			log := logger.NewLogger().WithTestConfig()
 			log.Init()
 
-			cfg, runtime := test.CreateTestConfigs(t)
 			runtime.OAuthProviders = map[string]model.OAuthServiceConfig{
-				"pocketid": tc.provider,
+				"pocketid": test.provider,
 			}
 
 			ctx, cancel := context.WithCancel(context.Background())
@@ -110,8 +110,8 @@ func TestSSOLogout(t *testing.T) {
 
 			store := memory.New()
 			var authService *service.AuthService
-			if tc.session != nil {
-				_, err := store.CreateSession(ctx, *tc.session)
+			if test.session != nil {
+				_, err := store.CreateSession(ctx, *test.session)
 				require.NoError(t, err)
 
 				dg := ding.New(ctx)
@@ -127,9 +127,9 @@ func TestSSOLogout(t *testing.T) {
 			}
 
 			router := gin.New()
-			if tc.userContext != nil {
+			if test.userContext != nil {
 				router.Use(func(c *gin.Context) {
-					c.Set("context", tc.userContext)
+					c.Set("context", test.userContext)
 					c.Next()
 				})
 			}
@@ -143,17 +143,17 @@ func TestSSOLogout(t *testing.T) {
 			})
 
 			recorder := httptest.NewRecorder()
-			req := httptest.NewRequest(http.MethodPost, tc.requestPath, nil)
-			if tc.session != nil {
+			req := httptest.NewRequest(http.MethodPost, test.requestPath, nil)
+			if test.session != nil {
 				req.AddCookie(&http.Cookie{
 					Name:  runtime.SessionCookieName,
-					Value: tc.session.UUID,
+					Value: test.session.UUID,
 				})
 			}
 
 			router.ServeHTTP(recorder, req)
 
-			tc.validate(t, recorder)
+			test.validate(t, recorder)
 		})
 	}
 }
@@ -194,15 +194,15 @@ func TestBuildOAuthLogoutURL(t *testing.T) {
 		},
 	}
 
-	for _, tc := range tests {
-		t.Run(tc.description, func(t *testing.T) {
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
 			got, err := buildOAuthLogoutURL(
-				tc.provider,
+				test.provider,
 				"https://auth.example.com/api/user/logout/callback",
 				"id-token",
 				"https://app.example.com/",
 			)
-			if tc.expectError {
+			if test.expectError {
 				require.Error(t, err)
 				return
 			}
@@ -210,7 +210,7 @@ func TestBuildOAuthLogoutURL(t *testing.T) {
 			require.NoError(t, err)
 			parsed, err := url.Parse(got)
 			require.NoError(t, err)
-			tc.validate(t, parsed)
+			test.validate(t, parsed)
 		})
 	}
 }

--- a/internal/controller/user_controller_test.go
+++ b/internal/controller/user_controller_test.go
@@ -577,6 +577,7 @@ func TestUserController(t *testing.T) {
 
 			NewUserController(UserControllerInput{
 				Log:           log,
+				StaticConfig:  &cfg,
 				RuntimeConfig: &runtime,
 				RouterGroup:   group,
 				AuthService:   authService,

--- a/internal/model/config.go
+++ b/internal/model/config.go
@@ -253,19 +253,23 @@ type TailscaleConfig struct {
 // OAuth/OIDC config
 
 type OAuthServiceConfig struct {
-	ClientID         string                `description:"OAuth client ID." yaml:"clientId,omitempty"`
-	ClientSecret     string                `description:"OAuth client secret." yaml:"clientSecret,omitempty"`
-	ClientSecretFile string                `description:"Path to the file containing the OAuth client secret." yaml:"clientSecretFile,omitempty"`
-	Whitelist        []string              `description:"Comma-separated list of allowed OAuth domains for this provider." yaml:"whitelist,omitempty"`
-	WhitelistFile    string                `description:"Path to the OAuth whitelist file for this provider." yaml:"whitelistFile,omitempty"`
-	Scopes           []string              `description:"OAuth scopes." yaml:"scopes,omitempty"`
-	RedirectURL      string                `description:"OAuth redirect URL." yaml:"redirectUrl,omitempty"`
-	AuthURL          string                `description:"OAuth authorization URL." yaml:"authUrl,omitempty"`
-	TokenURL         string                `description:"OAuth token URL." yaml:"tokenUrl,omitempty"`
-	UserinfoURL      string                `description:"OAuth userinfo URL." yaml:"userinfoUrl,omitempty"`
-	Insecure         bool                  `description:"Allow insecure OAuth connections." yaml:"insecure,omitempty"`
-	Name             string                `description:"Provider name in UI." yaml:"name,omitempty"`
-	Claims           OAuthServiceClaimsMap `description:"Map of claims to extract from the userinfo response." yaml:"claims,omitempty"`
+	ClientID         string   `description:"OAuth client ID." yaml:"clientId,omitempty"`
+	ClientSecret     string   `description:"OAuth client secret." yaml:"clientSecret,omitempty"`
+	ClientSecretFile string   `description:"Path to the file containing the OAuth client secret." yaml:"clientSecretFile,omitempty"`
+	Whitelist        []string `description:"Comma-separated list of allowed OAuth domains for this provider." yaml:"whitelist,omitempty"`
+	WhitelistFile    string   `description:"Path to the OAuth whitelist file for this provider." yaml:"whitelistFile,omitempty"`
+	Scopes           []string `description:"OAuth scopes." yaml:"scopes,omitempty"`
+	RedirectURL      string   `description:"OAuth redirect URL." yaml:"redirectUrl,omitempty"`
+	AuthURL          string   `description:"OAuth authorization URL." yaml:"authUrl,omitempty"`
+	TokenURL         string   `description:"OAuth token URL." yaml:"tokenUrl,omitempty"`
+	UserinfoURL      string   `description:"OAuth userinfo URL." yaml:"userinfoUrl,omitempty"`
+	// LogoutURL is the OpenID Provider end_session_endpoint used for
+	// OpenID Connect RP-Initiated Logout 1.0:
+	// https://openid.net/specs/openid-connect-rpinitiated-1_0-final.html#RPLogout
+	LogoutURL string                `description:"OpenID Connect RP-Initiated Logout end_session_endpoint URL." yaml:"logoutUrl,omitempty"`
+	Insecure  bool                  `description:"Allow insecure OAuth connections." yaml:"insecure,omitempty"`
+	Name      string                `description:"Provider name in UI." yaml:"name,omitempty"`
+	Claims    OAuthServiceClaimsMap `description:"Map of claims to extract from the userinfo response." yaml:"claims,omitempty"`
 }
 
 type OAuthServiceClaimsMap struct {

--- a/internal/model/context.go
+++ b/internal/model/context.go
@@ -48,6 +48,7 @@ type OAuthContext struct {
 	BaseContext
 	Groups      []string
 	Sub         string
+	IDToken     string
 	DisplayName string
 	ID          string
 }
@@ -159,6 +160,7 @@ func (c *UserContext) NewFromSession(session *repository.Session) (*UserContext,
 				return strings.Split(session.OAuthGroups, ",")
 			}(),
 			Sub:         session.OAuthSub,
+			IDToken:     session.OAuthIDToken,
 			DisplayName: session.OAuthName,
 			ID:          session.Provider,
 		}

--- a/internal/model/context_test.go
+++ b/internal/model/context_test.go
@@ -98,12 +98,12 @@ func TestContext(t *testing.T) {
 			run: func(t *testing.T, c *UserContext) any {
 				got, err := c.NewFromSession(&repository.Session{
 					Username: "dave", Provider: "github",
-					OAuthGroups: "devs,admins", OAuthSub: "sub-123", OAuthName: "GitHub",
+					OAuthGroups: "devs,admins", OAuthSub: "sub-123", OAuthIDToken: "id-token", OAuthName: "GitHub",
 				})
 				require.NoError(t, err)
-				return [5]any{got.Provider, got.OAuth.ID, got.OAuth.Sub, got.OAuth.DisplayName, got.OAuth.Groups}
+				return [6]any{got.Provider, got.OAuth.ID, got.OAuth.Sub, got.OAuth.IDToken, got.OAuth.DisplayName, got.OAuth.Groups}
 			},
-			expected: [5]any{ProviderOAuth, "github", "sub-123", "GitHub", []string{"devs", "admins"}},
+			expected: [6]any{ProviderOAuth, "github", "sub-123", "id-token", "GitHub", []string{"devs", "admins"}},
 		},
 		{
 			description: "Local getters return BaseContext fields",

--- a/internal/repository/memory/session_queries.go
+++ b/internal/repository/memory/session_queries.go
@@ -40,6 +40,7 @@ func (s *Store) UpdateSession(_ context.Context, arg repository.UpdateSessionPar
 	sess.Expiry = arg.Expiry
 	sess.OAuthName = arg.OAuthName
 	sess.OAuthSub = arg.OAuthSub
+	sess.OAuthIDToken = arg.OAuthIDToken
 	s.sessions[arg.UUID] = sess
 	return sess, nil
 }

--- a/internal/repository/models.go
+++ b/internal/repository/models.go
@@ -4,17 +4,18 @@ package repository
 // sqlc-generated driver packages use these via the conversion layer in their store.go.
 
 type Session struct {
-	UUID        string
-	Username    string
-	Email       string
-	Name        string
-	Provider    string
-	TotpPending bool
-	OAuthGroups string
-	Expiry      int64
-	CreatedAt   int64
-	OAuthName   string
-	OAuthSub    string
+	UUID         string
+	Username     string
+	Email        string
+	Name         string
+	Provider     string
+	TotpPending  bool
+	OAuthGroups  string
+	Expiry       int64
+	CreatedAt    int64
+	OAuthName    string
+	OAuthSub     string
+	OAuthIDToken string
 }
 
 type OidcSession struct {
@@ -30,30 +31,32 @@ type OidcSession struct {
 }
 
 type CreateSessionParams struct {
-	UUID        string
-	Username    string
-	Email       string
-	Name        string
-	Provider    string
-	TotpPending bool
-	OAuthGroups string
-	Expiry      int64
-	CreatedAt   int64
-	OAuthName   string
-	OAuthSub    string
+	UUID         string
+	Username     string
+	Email        string
+	Name         string
+	Provider     string
+	TotpPending  bool
+	OAuthGroups  string
+	Expiry       int64
+	CreatedAt    int64
+	OAuthName    string
+	OAuthSub     string
+	OAuthIDToken string
 }
 
 type UpdateSessionParams struct {
-	Username    string
-	Email       string
-	Name        string
-	Provider    string
-	TotpPending bool
-	OAuthGroups string
-	Expiry      int64
-	OAuthName   string
-	OAuthSub    string
-	UUID        string
+	Username     string
+	Email        string
+	Name         string
+	Provider     string
+	TotpPending  bool
+	OAuthGroups  string
+	Expiry       int64
+	OAuthName    string
+	OAuthSub     string
+	OAuthIDToken string
+	UUID         string
 }
 
 type CreateOIDCSessionParams struct {

--- a/internal/repository/postgres/models.go
+++ b/internal/repository/postgres/models.go
@@ -24,15 +24,16 @@ type OidcSession struct {
 }
 
 type Session struct {
-	UUID        string
-	Username    string
-	Email       string
-	Name        string
-	Provider    string
-	TotpPending bool
-	OAuthGroups string
-	Expiry      int64
-	CreatedAt   int64
-	OAuthName   string
-	OAuthSub    string
+	UUID         string
+	Username     string
+	Email        string
+	Name         string
+	Provider     string
+	TotpPending  bool
+	OAuthGroups  string
+	Expiry       int64
+	CreatedAt    int64
+	OAuthName    string
+	OAuthSub     string
+	OAuthIDToken string
 }

--- a/internal/repository/postgres/session_queries.sql.go
+++ b/internal/repository/postgres/session_queries.sql.go
@@ -21,25 +21,27 @@ INSERT INTO "sessions" (
     "expiry",
     "created_at",
     "oauth_name",
-    "oauth_sub"
+    "oauth_sub",
+    "oauth_id_token"
 ) VALUES (
-    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11
+    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12
 )
-RETURNING uuid, username, email, name, provider, totp_pending, oauth_groups, expiry, created_at, oauth_name, oauth_sub
+RETURNING uuid, username, email, name, provider, totp_pending, oauth_groups, expiry, created_at, oauth_name, oauth_sub, oauth_id_token
 `
 
 type CreateSessionParams struct {
-	UUID        string
-	Username    string
-	Email       string
-	Name        string
-	Provider    string
-	TotpPending bool
-	OAuthGroups string
-	Expiry      int64
-	CreatedAt   int64
-	OAuthName   string
-	OAuthSub    string
+	UUID         string
+	Username     string
+	Email        string
+	Name         string
+	Provider     string
+	TotpPending  bool
+	OAuthGroups  string
+	Expiry       int64
+	CreatedAt    int64
+	OAuthName    string
+	OAuthSub     string
+	OAuthIDToken string
 }
 
 func (q *Queries) CreateSession(ctx context.Context, arg CreateSessionParams) (Session, error) {
@@ -55,6 +57,7 @@ func (q *Queries) CreateSession(ctx context.Context, arg CreateSessionParams) (S
 		arg.CreatedAt,
 		arg.OAuthName,
 		arg.OAuthSub,
+		arg.OAuthIDToken,
 	)
 	var i Session
 	err := row.Scan(
@@ -69,6 +72,7 @@ func (q *Queries) CreateSession(ctx context.Context, arg CreateSessionParams) (S
 		&i.CreatedAt,
 		&i.OAuthName,
 		&i.OAuthSub,
+		&i.OAuthIDToken,
 	)
 	return i, err
 }
@@ -94,7 +98,7 @@ func (q *Queries) DeleteSession(ctx context.Context, uuid string) error {
 }
 
 const getSession = `-- name: GetSession :one
-SELECT uuid, username, email, name, provider, totp_pending, oauth_groups, expiry, created_at, oauth_name, oauth_sub FROM "sessions"
+SELECT uuid, username, email, name, provider, totp_pending, oauth_groups, expiry, created_at, oauth_name, oauth_sub, oauth_id_token FROM "sessions"
 WHERE "uuid" = $1
 `
 
@@ -113,6 +117,7 @@ func (q *Queries) GetSession(ctx context.Context, uuid string) (Session, error) 
 		&i.CreatedAt,
 		&i.OAuthName,
 		&i.OAuthSub,
+		&i.OAuthIDToken,
 	)
 	return i, err
 }
@@ -127,22 +132,24 @@ UPDATE "sessions" SET
     "oauth_groups" = $6,
     "expiry"       = $7,
     "oauth_name"   = $8,
-    "oauth_sub"    = $9
-WHERE "uuid" = $10
-RETURNING uuid, username, email, name, provider, totp_pending, oauth_groups, expiry, created_at, oauth_name, oauth_sub
+    "oauth_sub"    = $9,
+    "oauth_id_token" = $10
+WHERE "uuid" = $11
+RETURNING uuid, username, email, name, provider, totp_pending, oauth_groups, expiry, created_at, oauth_name, oauth_sub, oauth_id_token
 `
 
 type UpdateSessionParams struct {
-	Username    string
-	Email       string
-	Name        string
-	Provider    string
-	TotpPending bool
-	OAuthGroups string
-	Expiry      int64
-	OAuthName   string
-	OAuthSub    string
-	UUID        string
+	Username     string
+	Email        string
+	Name         string
+	Provider     string
+	TotpPending  bool
+	OAuthGroups  string
+	Expiry       int64
+	OAuthName    string
+	OAuthSub     string
+	OAuthIDToken string
+	UUID         string
 }
 
 func (q *Queries) UpdateSession(ctx context.Context, arg UpdateSessionParams) (Session, error) {
@@ -156,6 +163,7 @@ func (q *Queries) UpdateSession(ctx context.Context, arg UpdateSessionParams) (S
 		arg.Expiry,
 		arg.OAuthName,
 		arg.OAuthSub,
+		arg.OAuthIDToken,
 		arg.UUID,
 	)
 	var i Session
@@ -171,6 +179,7 @@ func (q *Queries) UpdateSession(ctx context.Context, arg UpdateSessionParams) (S
 		&i.CreatedAt,
 		&i.OAuthName,
 		&i.OAuthSub,
+		&i.OAuthIDToken,
 	)
 	return i, err
 }

--- a/internal/repository/sqlite/models.go
+++ b/internal/repository/sqlite/models.go
@@ -24,15 +24,16 @@ type OidcSession struct {
 }
 
 type Session struct {
-	UUID        string
-	Username    string
-	Email       string
-	Name        string
-	Provider    string
-	TotpPending bool
-	OAuthGroups string
-	Expiry      int64
-	CreatedAt   int64
-	OAuthName   string
-	OAuthSub    string
+	UUID         string
+	Username     string
+	Email        string
+	Name         string
+	Provider     string
+	TotpPending  bool
+	OAuthGroups  string
+	Expiry       int64
+	CreatedAt    int64
+	OAuthName    string
+	OAuthSub     string
+	OAuthIDToken string
 }

--- a/internal/repository/sqlite/session_queries.sql.go
+++ b/internal/repository/sqlite/session_queries.sql.go
@@ -21,25 +21,27 @@ INSERT INTO "sessions" (
     "expiry",
     "created_at",
     "oauth_name",
-    "oauth_sub"
+    "oauth_sub",
+    "oauth_id_token"
 ) VALUES (
-    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
 )
-RETURNING uuid, username, email, name, provider, totp_pending, oauth_groups, expiry, created_at, oauth_name, oauth_sub
+RETURNING uuid, username, email, name, provider, totp_pending, oauth_groups, expiry, created_at, oauth_name, oauth_sub, oauth_id_token
 `
 
 type CreateSessionParams struct {
-	UUID        string
-	Username    string
-	Email       string
-	Name        string
-	Provider    string
-	TotpPending bool
-	OAuthGroups string
-	Expiry      int64
-	CreatedAt   int64
-	OAuthName   string
-	OAuthSub    string
+	UUID         string
+	Username     string
+	Email        string
+	Name         string
+	Provider     string
+	TotpPending  bool
+	OAuthGroups  string
+	Expiry       int64
+	CreatedAt    int64
+	OAuthName    string
+	OAuthSub     string
+	OAuthIDToken string
 }
 
 func (q *Queries) CreateSession(ctx context.Context, arg CreateSessionParams) (Session, error) {
@@ -55,6 +57,7 @@ func (q *Queries) CreateSession(ctx context.Context, arg CreateSessionParams) (S
 		arg.CreatedAt,
 		arg.OAuthName,
 		arg.OAuthSub,
+		arg.OAuthIDToken,
 	)
 	var i Session
 	err := row.Scan(
@@ -69,6 +72,7 @@ func (q *Queries) CreateSession(ctx context.Context, arg CreateSessionParams) (S
 		&i.CreatedAt,
 		&i.OAuthName,
 		&i.OAuthSub,
+		&i.OAuthIDToken,
 	)
 	return i, err
 }
@@ -94,7 +98,7 @@ func (q *Queries) DeleteSession(ctx context.Context, uuid string) error {
 }
 
 const getSession = `-- name: GetSession :one
-SELECT uuid, username, email, name, provider, totp_pending, oauth_groups, expiry, created_at, oauth_name, oauth_sub FROM "sessions"
+SELECT uuid, username, email, name, provider, totp_pending, oauth_groups, expiry, created_at, oauth_name, oauth_sub, oauth_id_token FROM "sessions"
 WHERE "uuid" = ?
 `
 
@@ -113,6 +117,7 @@ func (q *Queries) GetSession(ctx context.Context, uuid string) (Session, error) 
 		&i.CreatedAt,
 		&i.OAuthName,
 		&i.OAuthSub,
+		&i.OAuthIDToken,
 	)
 	return i, err
 }
@@ -127,22 +132,24 @@ UPDATE "sessions" SET
     "oauth_groups" = ?,
     "expiry" = ?,
     "oauth_name" = ?,
-    "oauth_sub" = ?
+    "oauth_sub" = ?,
+    "oauth_id_token" = ?
 WHERE "uuid" = ?
-RETURNING uuid, username, email, name, provider, totp_pending, oauth_groups, expiry, created_at, oauth_name, oauth_sub
+RETURNING uuid, username, email, name, provider, totp_pending, oauth_groups, expiry, created_at, oauth_name, oauth_sub, oauth_id_token
 `
 
 type UpdateSessionParams struct {
-	Username    string
-	Email       string
-	Name        string
-	Provider    string
-	TotpPending bool
-	OAuthGroups string
-	Expiry      int64
-	OAuthName   string
-	OAuthSub    string
-	UUID        string
+	Username     string
+	Email        string
+	Name         string
+	Provider     string
+	TotpPending  bool
+	OAuthGroups  string
+	Expiry       int64
+	OAuthName    string
+	OAuthSub     string
+	OAuthIDToken string
+	UUID         string
 }
 
 func (q *Queries) UpdateSession(ctx context.Context, arg UpdateSessionParams) (Session, error) {
@@ -156,6 +163,7 @@ func (q *Queries) UpdateSession(ctx context.Context, arg UpdateSessionParams) (S
 		arg.Expiry,
 		arg.OAuthName,
 		arg.OAuthSub,
+		arg.OAuthIDToken,
 		arg.UUID,
 	)
 	var i Session
@@ -171,6 +179,7 @@ func (q *Queries) UpdateSession(ctx context.Context, arg UpdateSessionParams) (S
 		&i.CreatedAt,
 		&i.OAuthName,
 		&i.OAuthSub,
+		&i.OAuthIDToken,
 	)
 	return i, err
 }

--- a/internal/service/auth_service.go
+++ b/internal/service/auth_service.go
@@ -363,17 +363,18 @@ func (auth *AuthService) CreateSession(ctx context.Context, data repository.Sess
 	expiresAt := time.Now().Add(time.Duration(expiry) * time.Second)
 
 	session := repository.CreateSessionParams{
-		UUID:        u.String(),
-		Username:    data.Username,
-		Email:       data.Email,
-		Name:        data.Name,
-		Provider:    data.Provider,
-		TotpPending: data.TotpPending,
-		OAuthGroups: data.OAuthGroups,
-		Expiry:      expiresAt.Unix(),
-		CreatedAt:   time.Now().Unix(),
-		OAuthName:   data.OAuthName,
-		OAuthSub:    data.OAuthSub,
+		UUID:         u.String(),
+		Username:     data.Username,
+		Email:        data.Email,
+		Name:         data.Name,
+		Provider:     data.Provider,
+		TotpPending:  data.TotpPending,
+		OAuthGroups:  data.OAuthGroups,
+		Expiry:       expiresAt.Unix(),
+		CreatedAt:    time.Now().Unix(),
+		OAuthName:    data.OAuthName,
+		OAuthSub:     data.OAuthSub,
+		OAuthIDToken: data.OAuthIDToken,
 	}
 
 	_, err = auth.queries.CreateSession(ctx, session)
@@ -419,16 +420,17 @@ func (auth *AuthService) RefreshSession(ctx context.Context, uuid string) (*http
 	newExpiry := session.Expiry + refreshThreshold
 
 	_, err = auth.queries.UpdateSession(ctx, repository.UpdateSessionParams{
-		Username:    session.Username,
-		Email:       session.Email,
-		Name:        session.Name,
-		Provider:    session.Provider,
-		TotpPending: session.TotpPending,
-		OAuthGroups: session.OAuthGroups,
-		Expiry:      newExpiry,
-		OAuthName:   session.OAuthName,
-		OAuthSub:    session.OAuthSub,
-		UUID:        session.UUID,
+		Username:     session.Username,
+		Email:        session.Email,
+		Name:         session.Name,
+		Provider:     session.Provider,
+		TotpPending:  session.TotpPending,
+		OAuthGroups:  session.OAuthGroups,
+		Expiry:       newExpiry,
+		OAuthName:    session.OAuthName,
+		OAuthSub:     session.OAuthSub,
+		OAuthIDToken: session.OAuthIDToken,
+		UUID:         session.UUID,
 	})
 
 	if err != nil {

--- a/pkg/validators/domain_validator.go
+++ b/pkg/validators/domain_validator.go
@@ -87,6 +87,10 @@ func (v *DomainValidator) getURL(i string) (*url.URL, error) {
 			return nil, fmt.Errorf("missing host or scheme in url: %s", i)
 		}
 
+		if u.User != nil {
+			return nil, fmt.Errorf("userinfo is not supported")
+		}
+
 		return u, nil
 	}
 
@@ -108,6 +112,10 @@ func (v *DomainValidator) getURL(i string) (*url.URL, error) {
 
 	if u.Host == "" {
 		return nil, fmt.Errorf("missing host in url: %s", i)
+	}
+
+	if u.User != nil {
+		return nil, fmt.Errorf("userinfo is not supported")
 	}
 
 	return u, nil

--- a/pkg/validators/domain_validator_test.go
+++ b/pkg/validators/domain_validator_test.go
@@ -119,6 +119,13 @@ func TestDomainValidator_SafeHostname(t *testing.T) {
 			input:       "example.com",
 			expected:    "example.com",
 		},
+		{
+			description: "URL with userinfo should fail",
+			input:       "https://evil.example.net@example.com",
+			errorFunc: func(t *testing.T, e error) {
+				assert.ErrorContains(t, e, "userinfo is not supported")
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -250,6 +257,14 @@ func TestDomainValidator_Validate(t *testing.T) {
 			description: "Non matching hostnames should fail",
 			expected:    "example.com",
 			actual:      "foo.com",
+			errorFunc: func(t *testing.T, e error) {
+				assert.ErrorIs(t, e, ErrHostnameMismatch)
+			},
+		},
+		{
+			description: "Hostname ending with expected domain but not subdomain should fail",
+			expected:    "example.com",
+			actual:      "badexample.com",
 			errorFunc: func(t *testing.T, e error) {
 				assert.ErrorIs(t, e, ErrHostnameMismatch)
 			},

--- a/sql/postgres/session_queries.sql
+++ b/sql/postgres/session_queries.sql
@@ -10,9 +10,10 @@ INSERT INTO "sessions" (
     "expiry",
     "created_at",
     "oauth_name",
-    "oauth_sub"
+    "oauth_sub",
+    "oauth_id_token"
 ) VALUES (
-    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11
+    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12
 )
 RETURNING *;
 
@@ -34,8 +35,9 @@ UPDATE "sessions" SET
     "oauth_groups" = $6,
     "expiry"       = $7,
     "oauth_name"   = $8,
-    "oauth_sub"    = $9
-WHERE "uuid" = $10
+    "oauth_sub"    = $9,
+    "oauth_id_token" = $10
+WHERE "uuid" = $11
 RETURNING *;
 
 -- name: DeleteExpiredSessions :exec

--- a/sql/postgres/session_schemas.sql
+++ b/sql/postgres/session_schemas.sql
@@ -9,5 +9,6 @@ CREATE TABLE IF NOT EXISTS "sessions" (
     "expiry"       BIGINT  NOT NULL,
     "created_at"   BIGINT  NOT NULL,
     "oauth_name"   TEXT    NOT NULL DEFAULT '',
-    "oauth_sub"    TEXT    NOT NULL DEFAULT ''
+    "oauth_sub"    TEXT    NOT NULL DEFAULT '',
+    "oauth_id_token" TEXT  NOT NULL DEFAULT ''
 );

--- a/sql/sqlite/session_queries.sql
+++ b/sql/sqlite/session_queries.sql
@@ -10,9 +10,10 @@ INSERT INTO "sessions" (
     "expiry",
     "created_at",
     "oauth_name",
-    "oauth_sub"
+    "oauth_sub",
+    "oauth_id_token"
 ) VALUES (
-    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
 )
 RETURNING *;
 
@@ -34,7 +35,8 @@ UPDATE "sessions" SET
     "oauth_groups" = ?,
     "expiry" = ?,
     "oauth_name" = ?,
-    "oauth_sub" = ?
+    "oauth_sub" = ?,
+    "oauth_id_token" = ?
 WHERE "uuid" = ?
 RETURNING *;
 

--- a/sql/sqlite/session_schemas.sql
+++ b/sql/sqlite/session_schemas.sql
@@ -9,5 +9,6 @@ CREATE TABLE IF NOT EXISTS "sessions" (
     "expiry" INTEGER NOT NULL,
     "created_at" INTEGER NOT NULL,
     "oauth_name" TEXT NULL,
-    "oauth_sub" TEXT NULL
+    "oauth_sub" TEXT NULL,
+    "oauth_id_token" TEXT NOT NULL DEFAULT ''
 );

--- a/sqlc.yml
+++ b/sqlc.yml
@@ -12,6 +12,7 @@ sql:
           oauth_groups: "OAuthGroups"
           oauth_name: "OAuthName"
           oauth_sub: "OAuthSub"
+          oauth_id_token: "OAuthIDToken"
           redirect_uri: "RedirectURI"
         overrides:
           - column: "sessions.oauth_groups"
@@ -19,6 +20,8 @@ sql:
           - column: "sessions.oauth_name"
             go_type: "string"
           - column: "sessions.oauth_sub"
+            go_type: "string"
+          - column: "sessions.oauth_id_token"
             go_type: "string"
           - column: "sessions.ldap_groups"
             go_type: "string"
@@ -36,4 +39,5 @@ sql:
           oauth_groups: "OAuthGroups"
           oauth_name: "OAuthName"
           oauth_sub: "OAuthSub"
+          oauth_id_token: "OAuthIDToken"
           redirect_uri: "RedirectURI"


### PR DESCRIPTION
## Stack

- Current: #1094 — upstream provider RP-initiated logout
- Follow-up: #1102 — Tinyauth OIDC end-session endpoint (draft; merge after this PR)

OAuth-backed sessions currently only log out of Tinyauth. When the upstream provider keeps its SSO session, the next protected application access can immediately create a new Tinyauth session, so logout does not behave like an end-to-end sign-out for OIDC providers that support RP-initiated logout.

Add an optional OAuth provider logoutUrl for the OpenID Provider end_session_endpoint and keep the provider id_token server-side on the Tinyauth session. The logout handler now deletes the local session, builds the OP logout request with client_id, id_token_hint, post_logout_redirect_uri, and state, and returns that redirect to the frontend. The callback endpoint validates and restores the requested application return URL after the OP hop.

Persist oauth_id_token for SQLite, Postgres, memory, SQLC generated repositories, and store wrapper models so refreshed sessions retain the token. Add migrations for both database drivers. Update the logout page and quick actions menu to follow backend-provided redirect URLs while keeping Tinyauth redirect_uri separate from OIDC
post_logout_redirect_uri.

Cover the new behavior with controller tests for safe logout redirects, logout URL construction, and use of the server-side id_token. Enable TLS on the dev whoami route so the local Traefik setup exercises the secure-cookie and OIDC logout flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OpenID Connect single sign-out with configurable provider logout endpoints.
  * OAuth sign-out information is preserved across sessions and refreshes.
  * Added secure HTTPS access for the development diagnostic service.

* **Bug Fixes**
  * Improved protection against unsafe or cross-domain logout redirects, with a safe fallback destination.
  * Provider-supplied logout redirects are followed immediately when available.

* **Tests**
  * Added coverage for secure redirects and OpenID Connect logout handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->