### PR TITLE
feat(ui): allow configuring background via css instead of an image

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -205,6 +205,8 @@ TINYAUTH_UI_TITLE="Tinyauth"
 TINYAUTH_UI_FORGOTPASSWORDMESSAGE="You can change your password by changing the configuration."
 # Path to the background image.
 TINYAUTH_UI_BACKGROUNDIMAGE="/background.jpg"
+# Value of the CSS background property, takes precedence over the background image.
+TINYAUTH_UI_BACKGROUNDCSS=
 # Enable UI warnings.
 TINYAUTH_UI_WARNINGSENABLED=true
 

--- a/frontend/src/components/layout/layout.tsx
+++ b/frontend/src/components/layout/layout.tsx
@@ -15,11 +15,15 @@ const BaseLayout = ({ children }: { children: React.ReactNode }) => {
   return (
     <div
       className="flex flex-col justify-center items-center min-h-svh px-4"
-      style={{
-        backgroundImage: `url(${ui.backgroundImage})`,
-        backgroundSize: "cover",
-        backgroundPosition: "center",
-      }}
+      style={
+        ui.backgroundCss
+          ? { background: ui.backgroundCss }
+          : {
+              backgroundImage: `url(${ui.backgroundImage})`,
+              backgroundSize: "cover",
+              backgroundPosition: "center",
+            }
+      }
     >
       <div className="absolute top-4 right-4">
         <QuickActions />

--- a/frontend/src/schemas/app-context-schema.ts
+++ b/frontend/src/schemas/app-context-schema.ts
@@ -18,6 +18,7 @@ const uiSchema = z.object({
   title: z.string(),
   forgotPasswordMessage: z.string(),
   backgroundImage: z.string(),
+  backgroundCss: z.string(),
   warningsEnabled: z.boolean(),
 });
 

--- a/internal/controller/context_controller.go
+++ b/internal/controller/context_controller.go
@@ -56,6 +56,7 @@ type ACRUI struct {
 	Title                 string `json:"title"`
 	ForgotPasswordMessage string `json:"forgotPasswordMessage"`
 	BackgroundImage       string `json:"backgroundImage"`
+	BackgroundCSS         string `json:"backgroundCss"`
 	WarningsEnabled       bool   `json:"warningsEnabled"`
 }
 
@@ -161,6 +162,7 @@ func (controller *ContextController) appContextHandler(c *gin.Context) {
 			Title:                 controller.config.UI.Title,
 			ForgotPasswordMessage: controller.config.UI.ForgotPasswordMessage,
 			BackgroundImage:       controller.config.UI.BackgroundImage,
+			BackgroundCSS:         controller.config.UI.BackgroundCSS,
 			WarningsEnabled:       controller.config.UI.WarningsEnabled,
 		},
 		App: ACRApp{

--- a/internal/controller/context_controller_test.go
+++ b/internal/controller/context_controller_test.go
@@ -45,6 +45,7 @@ func TestContextController(t *testing.T) {
 						Title:                 cfg.UI.Title,
 						ForgotPasswordMessage: cfg.UI.ForgotPasswordMessage,
 						BackgroundImage:       cfg.UI.BackgroundImage,
+						BackgroundCSS:         cfg.UI.BackgroundCSS,
 						WarningsEnabled:       cfg.UI.WarningsEnabled,
 					},
 					App: ACRApp{

--- a/internal/model/config.go
+++ b/internal/model/config.go
@@ -205,6 +205,7 @@ type UIConfig struct {
 	Title                 string `description:"The title of the UI." yaml:"title,omitempty"`
 	ForgotPasswordMessage string `description:"Message displayed on the forgot password page." yaml:"forgotPasswordMessage,omitempty"`
 	BackgroundImage       string `description:"Path to the background image." yaml:"backgroundImage,omitempty"`
+	BackgroundCSS         string `description:"Value of the CSS background property, takes precedence over the background image." yaml:"backgroundCss,omitempty"`
 	WarningsEnabled       bool   `description:"Enable UI warnings." yaml:"warningsEnabled,omitempty"`
 }
 

--- a/internal/test/test.go
+++ b/internal/test/test.go
@@ -19,6 +19,7 @@ func CreateTestConfigs(t *testing.T) (model.Config, model.RuntimeConfig) {
 			Title:                 "Tinyauth Test",
 			ForgotPasswordMessage: "foo",
 			BackgroundImage:       "/background.jpg",
+			BackgroundCSS:         "linear-gradient(135deg, #03045e 0%, #0077b6 50%, #00b4d8 100%)",
 			WarningsEnabled:       true,
 		},
 		OAuth: model.OAuthConfig{


### PR DESCRIPTION
Thank you for Tinyauth! This is my first contribution to this project.

The default background image (foggy forest) transfers ~550kB over the wire on a cold cache. Many of my users run on spotty and slow connections and report that loading the background image causes severe UI flickering.

I'm aware that one may configure a custom, smaller background image via the `TINYAUTH_UI_BACKGROUNDIMAGE` setting, but I think I've found an even better solution for this scenario: The new `TINYAUTH_UI_BACKGROUNDCSS` config allows specifying the value of the backdrop's `background` CSS property. With modern browser's CSS capabilities, this allows for a surprising amount of creativity and doesn't require **any** additional network transfers.

For example, setting `TINYAUTH_UI_BACKGROUNDCSS="linear-gradient(135deg, #03045e 0%, #0077b6 50%, #00b4d8 100%)"` makes the UI look like this:
<img width="1280" height="800" alt="after" src="https://github.com/user-attachments/assets/8b0d510a-f6c1-4e42-9dc1-ab0688b38571" />

Your thoughts about this? Is anything missing from this PR?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring the UI background with a custom CSS value.
  * Custom background CSS takes precedence over the configured background image.
  * Added the `TINYAUTH_UI_BACKGROUNDCSS` environment variable for background customization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->