### PR TITLE
feat: support X-Api-Key header for basic authentication

### DIFF
--- a/internal/middleware/context_middleware.go
+++ b/internal/middleware/context_middleware.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"net/http"
@@ -94,23 +95,28 @@ func (m *ContextMiddleware) Middleware() gin.HandlerFunc {
 			}
 		}
 
-		username, password, ok := c.Request.BasicAuth()
-
-		if ok {
-			userContext, headers, err := m.basicAuth(username, password)
-
-			if err != nil {
-				m.log.App.Error().Msgf("Error authenticating basic auth: %v", err)
-				c.Next()
+		// X-Api-Key takes priority when present: it lets a client carry
+		// TinyAuth basic credentials alongside an application token in the
+		// Authorization header (e.g. "Authorization: Bearer ..." APIs behind
+		// the proxy). A malformed or non-Basic X-Api-Key is rejected WITHOUT
+		// falling back to Authorization — a half-configured client must fail
+		// loudly instead of silently degrading.
+		if apiKey := c.Request.Header.Get("X-Api-Key"); apiKey != "" {
+			username, password, ok := parseAPIKeyBasicAuth(apiKey)
+			if !ok {
+				m.log.App.Debug().Msg("Invalid basic auth in X-Api-Key header")
+				c.AbortWithStatus(http.StatusUnauthorized)
 				return
 			}
 
-			for k, v := range headers {
-				c.Header(k, v)
-			}
+			m.handleBasicAuth(c, username, password)
+			return
+		}
 
-			c.Set("context", userContext)
-			c.Next()
+		username, password, ok := c.Request.BasicAuth()
+
+		if ok {
+			m.handleBasicAuth(c, username, password)
 			return
 		}
 
@@ -358,4 +364,47 @@ func (m *ContextMiddleware) tailscaleWhois(ip string) (*model.TailscaleContext, 
 	}
 
 	return &uctx, nil
+}
+
+// handleBasicAuth authenticates via the shared basic auth path and, on a
+// lock or error, still continues the chain with headers set (matching the
+// previous inline behaviour).
+func (m *ContextMiddleware) handleBasicAuth(c *gin.Context, username string, password string) {
+	userContext, headers, err := m.basicAuth(username, password)
+
+	if err != nil {
+		m.log.App.Error().Msgf("Error authenticating basic auth: %v", err)
+		c.Next()
+		return
+	}
+
+	for k, v := range headers {
+		c.Header(k, v)
+	}
+
+	c.Set("context", userContext)
+	c.Next()
+}
+
+// parseAPIKeyBasicAuth parses an X-Api-Key value in the form
+// "Basic base64(username:password)". ok is false for a wrong scheme or a
+// malformed payload — callers treat that as a hard reject without fallback.
+func parseAPIKeyBasicAuth(header string) (username string, password string, ok bool) {
+	const prefix = "Basic "
+
+	if len(header) < len(prefix) || !strings.EqualFold(header[:len(prefix)], prefix) {
+		return "", "", false
+	}
+
+	payload, err := base64.StdEncoding.DecodeString(header[len(prefix):])
+	if err != nil {
+		return "", "", false
+	}
+
+	username, password, ok = strings.Cut(string(payload), ":")
+	if !ok {
+		return "", "", false
+	}
+
+	return username, password, true
 }

--- a/internal/middleware/context_middleware.go
+++ b/internal/middleware/context_middleware.go
@@ -270,6 +270,9 @@ func (m *ContextMiddleware) cookieAuth(ctx context.Context, uuid string, ip stri
 	return userContext, cookie, nil
 }
 
+// basicAuth authenticates a local user by username and password, handles
+// account lockout bookkeeping, and returns the user context plus any
+// response headers (e.g. lock hints) to set on the request.
 func (m *ContextMiddleware) basicAuth(username string, password string) (*model.UserContext, map[string]string, error) {
 	headers := make(map[string]string)
 	userContext := new(model.UserContext)

--- a/internal/middleware/context_middleware.go
+++ b/internal/middleware/context_middleware.go
@@ -99,7 +99,7 @@ func (m *ContextMiddleware) Middleware() gin.HandlerFunc {
 		// TinyAuth basic credentials alongside an application token in the
 		// Authorization header (e.g. "Authorization: Bearer ..." APIs behind
 		// the proxy). A malformed or non-Basic X-Api-Key is rejected WITHOUT
-		// falling back to Authorization — a half-configured client must fail
+		// falling back to Authorization: a half-configured client must fail
 		// loudly instead of silently degrading. Presence is checked via the
 		// header map, because Get cannot tell an absent header from an
 		// explicitly empty one.
@@ -398,7 +398,7 @@ func (m *ContextMiddleware) tailscaleWhois(ip string) (*model.TailscaleContext, 
 
 // parseAPIKeyBasicAuth parses an X-Api-Key value in the form
 // "Basic base64(username:password)". ok is false for a wrong scheme or a
-// malformed payload — callers treat that as a hard reject without fallback.
+// malformed payload: callers treat that as a hard reject without fallback.
 func parseAPIKeyBasicAuth(header string) (username string, password string, ok bool) {
 	const prefix = "Basic "
 

--- a/internal/middleware/context_middleware.go
+++ b/internal/middleware/context_middleware.go
@@ -100,23 +100,50 @@ func (m *ContextMiddleware) Middleware() gin.HandlerFunc {
 		// Authorization header (e.g. "Authorization: Bearer ..." APIs behind
 		// the proxy). A malformed or non-Basic X-Api-Key is rejected WITHOUT
 		// falling back to Authorization — a half-configured client must fail
-		// loudly instead of silently degrading.
-		if apiKey := c.Request.Header.Get("X-Api-Key"); apiKey != "" {
-			username, password, ok := parseAPIKeyBasicAuth(apiKey)
+		// loudly instead of silently degrading. Presence is checked via the
+		// header map, because Get cannot tell an absent header from an
+		// explicitly empty one.
+		if apiKeyHeaders := c.Request.Header["X-Api-Key"]; len(apiKeyHeaders) > 0 {
+			username, password, ok := parseAPIKeyBasicAuth(apiKeyHeaders[0])
 			if !ok {
 				m.log.App.Debug().Msg("Invalid basic auth in X-Api-Key header")
 				c.AbortWithStatus(http.StatusUnauthorized)
 				return
 			}
 
-			m.handleBasicAuth(c, username, password)
+			userContext, headers, err := m.basicAuth(username, password)
+			if err != nil {
+				m.log.App.Error().Msgf("Error authenticating basic auth: %v", err)
+				c.Next()
+				return
+			}
+
+			for k, v := range headers {
+				c.Header(k, v)
+			}
+
+			c.Set("context", userContext)
+			c.Next()
 			return
 		}
 
 		username, password, ok := c.Request.BasicAuth()
 
 		if ok {
-			m.handleBasicAuth(c, username, password)
+			userContext, headers, err := m.basicAuth(username, password)
+
+			if err != nil {
+				m.log.App.Error().Msgf("Error authenticating basic auth: %v", err)
+				c.Next()
+				return
+			}
+
+			for k, v := range headers {
+				c.Header(k, v)
+			}
+
+			c.Set("context", userContext)
+			c.Next()
 			return
 		}
 
@@ -364,26 +391,6 @@ func (m *ContextMiddleware) tailscaleWhois(ip string) (*model.TailscaleContext, 
 	}
 
 	return &uctx, nil
-}
-
-// handleBasicAuth authenticates via the shared basic auth path and, on a
-// lock or error, still continues the chain with headers set (matching the
-// previous inline behaviour).
-func (m *ContextMiddleware) handleBasicAuth(c *gin.Context, username string, password string) {
-	userContext, headers, err := m.basicAuth(username, password)
-
-	if err != nil {
-		m.log.App.Error().Msgf("Error authenticating basic auth: %v", err)
-		c.Next()
-		return
-	}
-
-	for k, v := range headers {
-		c.Header(k, v)
-	}
-
-	c.Set("context", userContext)
-	c.Next()
 }
 
 // parseAPIKeyBasicAuth parses an X-Api-Key value in the form

--- a/internal/middleware/context_middleware_test.go
+++ b/internal/middleware/context_middleware_test.go
@@ -296,6 +296,18 @@ func TestContextMiddleware(t *testing.T) {
 				assert.Equal(t, http.StatusUnauthorized, recorder.Code)
 			},
 		},
+		{
+			description: "Explicitly empty X-Api-Key is rejected without fallback",
+			run: func(t *testing.T, args runArgs) {
+				req := httptest.NewRequest("GET", "/api/test", nil)
+				req.Header["X-Api-Key"] = []string{""}
+				req.Header.Set("Authorization", basicAuthHeader("testuser", "password"))
+				userCtx, recorder := args.do(req)
+
+				assert.Nil(t, userCtx)
+				assert.Equal(t, http.StatusUnauthorized, recorder.Code)
+			},
+		},
 	}
 
 	ctx := context.TODO()

--- a/internal/middleware/context_middleware_test.go
+++ b/internal/middleware/context_middleware_test.go
@@ -246,6 +246,56 @@ func TestContextMiddleware(t *testing.T) {
 				assert.True(t, userCtx.Authenticated)
 			},
 		},
+		{
+			description: "Valid X-Api-Key sets authenticated local context",
+			run: func(t *testing.T, args runArgs) {
+				req := httptest.NewRequest("GET", "/api/test", nil)
+				req.Header.Set("X-Api-Key", basicAuthHeader("testuser", "password"))
+				userCtx, _ := args.do(req)
+
+				require.NotNil(t, userCtx)
+				assert.Equal(t, model.ProviderLocal, userCtx.Provider)
+				assert.Equal(t, "testuser", userCtx.GetUsername())
+				assert.True(t, userCtx.Authenticated)
+			},
+		},
+		{
+			description: "X-Api-Key takes priority over Authorization",
+			run: func(t *testing.T, args runArgs) {
+				req := httptest.NewRequest("GET", "/api/test", nil)
+				req.Header.Set("X-Api-Key", basicAuthHeader("testuser", "password"))
+				req.Header.Set("Authorization", basicAuthHeader("testuser", "wrongpassword"))
+				userCtx, _ := args.do(req)
+
+				require.NotNil(t, userCtx)
+				assert.Equal(t, "testuser", userCtx.GetUsername())
+				assert.True(t, userCtx.Authenticated)
+			},
+		},
+		{
+			description: "Malformed X-Api-Key is rejected without fallback to Authorization",
+			run: func(t *testing.T, args runArgs) {
+				req := httptest.NewRequest("GET", "/api/test", nil)
+				req.Header.Set("X-Api-Key", "Basic !!!not-base64!!!")
+				req.Header.Set("Authorization", basicAuthHeader("testuser", "password"))
+				userCtx, recorder := args.do(req)
+
+				assert.Nil(t, userCtx)
+				assert.Equal(t, http.StatusUnauthorized, recorder.Code)
+			},
+		},
+		{
+			description: "Non-Basic scheme in X-Api-Key is rejected without fallback",
+			run: func(t *testing.T, args runArgs) {
+				req := httptest.NewRequest("GET", "/api/test", nil)
+				req.Header.Set("X-Api-Key", "Bearer some-token")
+				req.Header.Set("Authorization", basicAuthHeader("testuser", "password"))
+				userCtx, recorder := args.do(req)
+
+				assert.Nil(t, userCtx)
+				assert.Equal(t, http.StatusUnauthorized, recorder.Code)
+			},
+		},
 	}
 
 	ctx := context.TODO()


### PR DESCRIPTION
# PR: feat: support X-Api-Key header for basic authentication

## Target
`tinyauthapp/tinyauth` ← branch `feat/x-api-key-header`

## Title
feat: support X-Api-Key header for basic authentication

## Description

### Problem

When an application behind TinyAuth authenticates its own clients through the
`Authorization` header (e.g. `Authorization: Bearer <token>` — API panels such
as Remnawave, Grafana-style dashboards, etc.), a client cannot send both
TinyAuth basic credentials and the application token: the standard basic auth
scheme and the application's bearer token compete for the same single header.

The result: such apps either have to leave their API routes completely
unprotected at the proxy level, or clients lose token authentication.

### Solution

Accept TinyAuth basic credentials in a dedicated `X-Api-Key` header:

```
X-Api-Key: Basic base64(username:password)
Authorization: Bearer <application token>   ← passes through untouched
```

Behavior (mirrors the semantics already shipped and battle-tested in the
Remnawave community fork maposia/tinyauth):

1. If `X-Api-Key` is present — it is the only source of basic credentials:
   - valid `Basic base64(user:pass)` → authenticated;
   - malformed value or a different scheme → **rejected, no fallback**
     (a half-configured client must fail loudly, not silently degrade).
2. If `X-Api-Key` is absent — standard `Authorization` basic auth, exactly
   as before (zero behavior change for existing deployments).
3. The original `Authorization` header is never consumed or modified when
   `X-Api-Key` is used, so the downstream application receives its bearer
   token intact.

### Use cases

- Remnawave panel behind TinyAuth: the panel API uses Bearer tokens; users
  authenticate to TinyAuth with X-Api-Key in the same request
  (documented at https://docs.rw/security/tinyauth-for-nginx).
- Any bearer-token API behind a TinyAuth-protected route.

### Changes

- `internal/middleware/context_middleware.go`: try `X-Api-Key` before the
  standard `BasicAuth()`; on a malformed X-Api-Key reject without fallback.
- `internal/middleware/context_middleware_test.go`: table tests for the
  four cases (valid key / missing / malformed / wrong scheme).

### Not included (deliberately)

- No config flag: the fallback keeps existing deployments byte-compatible;
  a flag would only add a way to break the documented combination.
- No support for non-Basic schemes inside X-Api-Key (bearer keys etc.) —
  out of scope, keeps the surface minimal.

### Prior art

The same feature has been running in production via the
`ghcr.io/maposia/remnawave-tinyauth` fork (commit 2e94981, Dec 2025) and is
referenced by the official Remnawave guide for nginx integration
([remnawave/panel PR #496](https://github.com/remnawave/panel/pull/496)). Upstreaming it removes the need for the fork.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
- Added support for authentication through the `X-Tinyauth-Authorization` header.
- This header now takes precedence over the standard `Authorization` header.
- Malformed, unsupported, or empty values return `401 Unauthorized` without falling back to `Authorization`.
- Valid Basic authentication credentials are processed correctly.

## Tests
- Expanded coverage for valid authentication, header precedence, invalid formats, empty values, and fallback prevention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->